### PR TITLE
Regressor immutable memory saving

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main2() -> Result<(), Box<dyn Error>>  {
         let filename = cl.value_of("initial_regressor").expect("Daemon mode only supports serving from --initial regressor");
         println!("initial_regressor = {}", filename);
         println!("WARNING: Command line model parameters will be ignored");
-        let (mi2, vw2, re_fixed) = persistence::new_fixed_regressor_from_filename(filename)?;
+        let (mi2, vw2, re_fixed) = persistence::new_immutable_regressor_from_filename(filename)?;
         mi = mi2; vw = vw2;
         let mut se = serving::Serving::new(&cl, &vw, re_fixed, &mi)?;
         se.serve()?;
@@ -82,7 +82,7 @@ fn main2() -> Result<(), Box<dyn Error>>  {
         if let Some(filename) = cl.value_of("initial_regressor") {
             println!("initial_regressor = {}", filename);
             println!("WARNING: Command line model parameters will be ignored");
-            let (mi2, vw2, re2) = persistence::new_regressor_from_filename(filename)?;
+            let (mi2, vw2, re2) = persistence::new_regressor_from_filename(filename, testonly)?;
             mi = mi2; vw = vw2; re = re2;
         } else {
             // We load vw_namespace_map.csv just so we know all the namespaces ahead of time

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -256,12 +256,13 @@ B,featureB
         ffm_fixed_init(&mut re);
         let fbuf = &ffm_vec(vec![
                                   HashAndValueAndSeq{hash:1, value: 1.0, contra_field_index: 0},
+                                  HashAndValueAndSeq{hash:2, value: 1.0, contra_field_index: 0},
                                   HashAndValueAndSeq{hash:100, value: 2.0, contra_field_index: 1}
                                   ], 2);
         p = re.learn(fbuf, true, 0);
-        assert_eq!(p, 0.880797); 
+        assert_eq!(p, 0.9933072); 
         p = re.learn(fbuf, false, 0);
-        let CONST_RESULT = 0.79534113;
+        let CONST_RESULT = 0.92014676;
         assert_eq!(p, CONST_RESULT);
 
         // Now we test conversion to fixed regressor 

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -473,7 +473,6 @@ impl ImmutableRegressor {
                //     if left_hash.contra_field_index == right_hash.contra_field_index {
                //         continue	// not combining within a field
                //     }
-               // WRITE A UNIT TEST TO VERIFY COMPATIBILITY between immutable and regular regressor in the case above
                     let joint_value = left_hash.value * right_hash.value;
                     let lindex = (self.ffm_weights_offset as u32 + ((left_hash.hash & self.ffm_hashmask) + right_hash.contra_field_index)) as u32;
                     let rindex = (self.ffm_weights_offset as u32 + ((right_hash.hash & self.ffm_hashmask) + left_hash.contra_field_index)) as u32;
@@ -504,8 +503,6 @@ impl ImmutableRegressor {
         prediction_probability
         }
     }
-    
-
 } 
 
 


### PR DESCRIPTION
Don't load optimizer's data to memory in testonly mode.
This uses the same mechanism --daemon already used.
Looks better in the chart. And should be faster.