### PR TITLE
Regressor optimize immutable

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main2() -> Result<(), Box<dyn Error>>  {
         let filename = cl.value_of("initial_regressor").expect("Daemon mode only supports serving from --initial regressor");
         println!("initial_regressor = {}", filename);
         println!("WARNING: Command line model parameters will be ignored");
-        let (mi2, vw2, re_fixed) = persistence::new_fixed_regressor_from_filename(filename)?;
+        let (mi2, vw2, re_fixed) = persistence::new_immutable_regressor_from_filename(filename)?;
         mi = mi2; vw = vw2;
         let mut se = serving::Serving::new(&cl, &vw, re_fixed, &mi)?;
         se.serve()?;
@@ -82,7 +82,7 @@ fn main2() -> Result<(), Box<dyn Error>>  {
         if let Some(filename) = cl.value_of("initial_regressor") {
             println!("initial_regressor = {}", filename);
             println!("WARNING: Command line model parameters will be ignored");
-            let (mi2, vw2, re2) = persistence::new_regressor_from_filename(filename)?;
+            let (mi2, vw2, re2) = persistence::new_regressor_from_filename(filename, testonly)?;
             mi = mi2; vw = vw2; re = re2;
         } else {
             // We load vw_namespace_map.csv just so we know all the namespaces ahead of time

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -295,13 +295,11 @@ impl ModelInstance {
 
         // We currently only support SGD + adaptive, which means both options have to be specified
         if cl.is_present("sgd") {
-            //   return Err(Box::new(IOError::new(ErrorKind::Other, format!("You must use --sgd"))))
             mi.optimizer = Optimizer::SGD;
         }
 
         if cl.is_present("adaptive") {
             mi.optimizer = Optimizer::Adagrad;
-            //       return Err(Box::new(IOError::new(ErrorKind::Other, format!("You must use --adaptive"))))
         }
 
         

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -30,8 +30,7 @@ pub struct ModelInstance {
     pub minimum_learning_rate: f32,
     pub power_t: f32,
     pub bit_precision: u8,
-    // This should have been called "lr_hash_mask"
-    pub hash_mask: u32,
+    pub hash_mask: u32,		// DEPRECATED, UNUSED -- this is recalculated in feature_buffer.rs
     pub add_constant_feature: bool,
     pub feature_combo_descs: Vec<FeatureComboDesc>,
     pub ffm_fields: Vec<Vec<usize>>,
@@ -40,7 +39,7 @@ pub struct ModelInstance {
     #[serde(default = "default_u32_zero")]
     pub ffm_bit_precision: u32,
     #[serde(default = "default_bool_false")]
-    pub ffm_separate_vectors: bool, // NOT USED
+    pub ffm_separate_vectors: bool, // DEPRECATED, UNUSED
     #[serde(default = "default_bool_false")]
     pub fastmath: bool,
 
@@ -110,7 +109,7 @@ impl ModelInstance {
             ffm_learning_rate: 0.5, // vw default
             minimum_learning_rate: 0.0, 
             bit_precision: 18,      // vw default
-            hash_mask: (1 << 18) -1,
+            hash_mask: 0, // DEPRECATED, UNUSED
             power_t: 0.5,
             ffm_power_t: 0.5,
             add_constant_feature: true,
@@ -118,7 +117,7 @@ impl ModelInstance {
             ffm_fields: Vec::new(),
             ffm_k: 0,
             ffm_bit_precision: 18,
-            ffm_separate_vectors: false,
+            ffm_separate_vectors: false, // DEPRECATED, UNUSED
             fastmath: true,
             ffm_k_threshold: 0.0,
             ffm_init_center: 0.0,
@@ -151,12 +150,18 @@ impl ModelInstance {
             // numeric precomputed hashes. This is even default option.
             // It is generally a bad idea except if you strings really are precomputed hashes... 
             if !cl.is_present("hash") {
-                   return Err(Box::new(IOError::new(ErrorKind::Other, format!("You have to use --hash all "))))
+                   return Err(Box::new(IOError::new(ErrorKind::Other, format!("--vwcompat requires use of --hash all"))))
             } else
+
             if let Some(val) = cl.value_of("hash") {
                 if val != "all" {
-                    return Err(Box::new(IOError::new(ErrorKind::Other, format!("Only --hash all supported"))))
+                    return Err(Box::new(IOError::new(ErrorKind::Other, format!("--vwcompat requires use of --hash all"))))
                 }            
+            }
+
+            // --sgd will turn off adaptive, invariant and normalization in vowpal. You can turn adaptive back on in vw and fw with --adaptive
+            if !cl.is_present("sgd") {
+                return Err(Box::new(IOError::new(ErrorKind::Other, format!("--vwcompat requires use of --sgd"))))
             }
             
         
@@ -240,7 +245,6 @@ impl ModelInstance {
         if let Some(val) = cl.value_of("bit_precision") {
             mi.bit_precision = val.parse()?;
             println!("Num weight bits = {}", mi.bit_precision); // vwcompat
-            mi.hash_mask = (1 << mi.bit_precision) -1;
         }
 
         if let Some(val) = cl.value_of("learning_rate") {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -256,12 +256,13 @@ B,featureB
         ffm_fixed_init(&mut re);
         let fbuf = &ffm_vec(vec![
                                   HashAndValueAndSeq{hash:1, value: 1.0, contra_field_index: 0},
+                                  HashAndValueAndSeq{hash:2, value: 1.0, contra_field_index: 0},
                                   HashAndValueAndSeq{hash:100, value: 2.0, contra_field_index: 1}
                                   ], 2);
         p = re.learn(fbuf, true, 0);
-        assert_eq!(p, 0.880797); 
+        assert_eq!(p, 0.9933072); 
         p = re.learn(fbuf, false, 0);
-        let CONST_RESULT = 0.79534113;
+        let CONST_RESULT = 0.92014676;
         assert_eq!(p, CONST_RESULT);
 
         // Now we test conversion to fixed regressor 

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -266,13 +266,13 @@ B,featureB
         ffm_fixed_init(&mut re);
         let fbuf = &ffm_vec(vec![
                                   HashAndValueAndSeq{hash:1, value: 1.0, contra_field_index: 0},
-                                  HashAndValueAndSeq{hash:2, value: 1.0, contra_field_index: 0},
+                                  HashAndValueAndSeq{hash:3 * 1000, value: 1.0, contra_field_index: 0},
                                   HashAndValueAndSeq{hash:100, value: 2.0, contra_field_index: 1}
                                   ], 2);
         p = re.learn(fbuf, true, 0);
         assert_eq!(p, 0.9933072); 
         p = re.learn(fbuf, false, 0);
-        let CONST_RESULT = 0.92014676;
+        let CONST_RESULT = 0.9395168;
         assert_eq!(p, CONST_RESULT);
 
         // Now we test conversion to fixed regressor 
@@ -300,7 +300,9 @@ B,featureB
             // c) load as fixed regressor
             let (_mi2, _vw2, re_fixed) = new_immutable_regressor_from_filename(regressor_filepath.to_str().unwrap()).unwrap();
             assert_eq!(re_fixed.predict(fbuf, 0), CONST_RESULT);
+        
         }
+        
 
     }    
 

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -473,7 +473,6 @@ impl ImmutableRegressor {
                //     if left_hash.contra_field_index == right_hash.contra_field_index {
                //         continue	// not combining within a field
                //     }
-               // WRITE A UNIT TEST TO VERIFY COMPATIBILITY between immutable and regular regressor in the case above
                     let joint_value = left_hash.value * right_hash.value;
                     let lindex = (self.ffm_weights_offset as u32 + ((left_hash.hash & self.ffm_hashmask) + right_hash.contra_field_index)) as u32;
                     let rindex = (self.ffm_weights_offset as u32 + ((right_hash.hash & self.ffm_hashmask) + left_hash.contra_field_index)) as u32;
@@ -504,8 +503,6 @@ impl ImmutableRegressor {
         prediction_probability
         }
     }
-    
-
 } 
 
 


### PR DESCRIPTION
- slight optimizations of serving speed by doing masking of bits feature_buffer.rs instead of regressor inner (double) loop
- also cleans up the code regrading hash_masks
- also small cleanups around other variables. (sorry this was meant as a separate patch, but got commited accidentially)