### PR TITLE
Regressor optimizations

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -74,7 +74,7 @@ fn main2() -> Result<(), Box<dyn Error>>  {
         let filename = cl.value_of("initial_regressor").expect("Daemon mode only supports serving from --initial regressor");
         println!("initial_regressor = {}", filename);
         println!("WARNING: Command line model parameters will be ignored");
-        let (mi2, vw2, re_fixed) = persistence::new_fixed_regressor_from_filename(filename)?;
+        let (mi2, vw2, re_fixed) = persistence::new_immutable_regressor_from_filename(filename)?;
         mi = mi2; vw = vw2;
         let mut se = serving::Serving::new(&cl, &vw, re_fixed, &mi)?;
         se.serve()?;
@@ -82,7 +82,7 @@ fn main2() -> Result<(), Box<dyn Error>>  {
         if let Some(filename) = cl.value_of("initial_regressor") {
             println!("initial_regressor = {}", filename);
             println!("WARNING: Command line model parameters will be ignored");
-            let (mi2, vw2, re2) = persistence::new_regressor_from_filename(filename)?;
+            let (mi2, vw2, re2) = persistence::new_regressor_from_filename(filename, testonly)?;
             mi = mi2; vw = vw2; re = re2;
         } else {
             // We load vw_namespace_map.csv just so we know all the namespaces ahead of time

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -295,13 +295,11 @@ impl ModelInstance {
 
         // We currently only support SGD + adaptive, which means both options have to be specified
         if cl.is_present("sgd") {
-            //   return Err(Box::new(IOError::new(ErrorKind::Other, format!("You must use --sgd"))))
             mi.optimizer = Optimizer::SGD;
         }
 
         if cl.is_present("adaptive") {
             mi.optimizer = Optimizer::Adagrad;
-            //       return Err(Box::new(IOError::new(ErrorKind::Other, format!("You must use --adaptive"))))
         }
 
         

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -30,8 +30,7 @@ pub struct ModelInstance {
     pub minimum_learning_rate: f32,
     pub power_t: f32,
     pub bit_precision: u8,
-    // This should have been called "lr_hash_mask"
-    pub hash_mask: u32,
+    pub hash_mask: u32,		// DEPRECATED, UNUSED -- this is recalculated in feature_buffer.rs
     pub add_constant_feature: bool,
     pub feature_combo_descs: Vec<FeatureComboDesc>,
     pub ffm_fields: Vec<Vec<usize>>,
@@ -40,7 +39,7 @@ pub struct ModelInstance {
     #[serde(default = "default_u32_zero")]
     pub ffm_bit_precision: u32,
     #[serde(default = "default_bool_false")]
-    pub ffm_separate_vectors: bool, // NOT USED
+    pub ffm_separate_vectors: bool, // DEPRECATED, UNUSED
     #[serde(default = "default_bool_false")]
     pub fastmath: bool,
 
@@ -110,7 +109,7 @@ impl ModelInstance {
             ffm_learning_rate: 0.5, // vw default
             minimum_learning_rate: 0.0, 
             bit_precision: 18,      // vw default
-            hash_mask: (1 << 18) -1,
+            hash_mask: 0, // DEPRECATED, UNUSED
             power_t: 0.5,
             ffm_power_t: 0.5,
             add_constant_feature: true,
@@ -118,7 +117,7 @@ impl ModelInstance {
             ffm_fields: Vec::new(),
             ffm_k: 0,
             ffm_bit_precision: 18,
-            ffm_separate_vectors: false,
+            ffm_separate_vectors: false, // DEPRECATED, UNUSED
             fastmath: true,
             ffm_k_threshold: 0.0,
             ffm_init_center: 0.0,
@@ -151,12 +150,18 @@ impl ModelInstance {
             // numeric precomputed hashes. This is even default option.
             // It is generally a bad idea except if you strings really are precomputed hashes... 
             if !cl.is_present("hash") {
-                   return Err(Box::new(IOError::new(ErrorKind::Other, format!("You have to use --hash all "))))
+                   return Err(Box::new(IOError::new(ErrorKind::Other, format!("--vwcompat requires use of --hash all"))))
             } else
+
             if let Some(val) = cl.value_of("hash") {
                 if val != "all" {
-                    return Err(Box::new(IOError::new(ErrorKind::Other, format!("Only --hash all supported"))))
+                    return Err(Box::new(IOError::new(ErrorKind::Other, format!("--vwcompat requires use of --hash all"))))
                 }            
+            }
+
+            // --sgd will turn off adaptive, invariant and normalization in vowpal. You can turn adaptive back on in vw and fw with --adaptive
+            if !cl.is_present("sgd") {
+                return Err(Box::new(IOError::new(ErrorKind::Other, format!("--vwcompat requires use of --sgd"))))
             }
             
         
@@ -240,7 +245,6 @@ impl ModelInstance {
         if let Some(val) = cl.value_of("bit_precision") {
             mi.bit_precision = val.parse()?;
             println!("Num weight bits = {}", mi.bit_precision); // vwcompat
-            mi.hash_mask = (1 << mi.bit_precision) -1;
         }
 
         if let Some(val) = cl.value_of("learning_rate") {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -266,13 +266,13 @@ B,featureB
         ffm_fixed_init(&mut re);
         let fbuf = &ffm_vec(vec![
                                   HashAndValueAndSeq{hash:1, value: 1.0, contra_field_index: 0},
-                                  HashAndValueAndSeq{hash:2, value: 1.0, contra_field_index: 0},
+                                  HashAndValueAndSeq{hash:3 * 1000, value: 1.0, contra_field_index: 0},
                                   HashAndValueAndSeq{hash:100, value: 2.0, contra_field_index: 1}
                                   ], 2);
         p = re.learn(fbuf, true, 0);
         assert_eq!(p, 0.9933072); 
         p = re.learn(fbuf, false, 0);
-        let CONST_RESULT = 0.92014676;
+        let CONST_RESULT = 0.9395168;
         assert_eq!(p, CONST_RESULT);
 
         // Now we test conversion to fixed regressor 
@@ -300,7 +300,9 @@ B,featureB
             // c) load as fixed regressor
             let (_mi2, _vw2, re_fixed) = new_immutable_regressor_from_filename(regressor_filepath.to_str().unwrap()).unwrap();
             assert_eq!(re_fixed.predict(fbuf, 0), CONST_RESULT);
+        
         }
+        
 
     }    
 

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -380,6 +380,8 @@ L: std::clone::Clone
             // Slow-path - using heap data structures
             if local_data_ffm_len > self.local_data_ffm_indices.len() {
                 self.local_data_ffm_indices.reserve(local_data_ffm_len - self.local_data_ffm_indices.len() + 1024);
+            }
+            if local_data_ffm_len > self.local_data_ffm_values.len() {
                 self.local_data_ffm_values.reserve(local_data_ffm_len - self.local_data_ffm_values.len() + 1024);
             }
             let local_data_ffm_indices = &mut self.local_data_ffm_indices;

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -242,10 +242,11 @@ L: std::clone::Clone
             ($local_data_ffm:ident) => {
              
                 let mut local_data_ffm = $local_data_ffm;
-                let weights = &self.weights;
-
-
                 let mut wsum:f32 = 0.0;
+
+                {let weights = &self.weights;
+
+
                 for (i, hashvalue) in fb.lr_buffer.iter().enumerate() {
                     // Prefetch couple of indexes from the future to prevent pipeline stalls due to memory latencies
                     _mm_prefetch(mem::transmute::<&f32, &i8>(&weights.get_unchecked((fb.lr_buffer.get_unchecked(i+8).hash) as usize).weight), _MM_HINT_T0);  // No benefit for now
@@ -253,18 +254,19 @@ L: std::clone::Clone
                     let feature_value:f32 = hashvalue.value;
                     let feature_weight    = weights.get_unchecked(feature_index as usize).weight;
                     wsum += feature_weight * feature_value;
-                }
-                
+                }}
+                {
+                let ffm_weights = &self.weights[self.ffm_weights_offset as usize..];
                 if self.ffm_k > 0 {
                     let fc = (fb.ffm_fields_count  * self.ffm_k) as usize;
                     let mut ifc:usize = 0;
                     for (i, left_hash) in fb.ffm_buffer.iter().enumerate() {
-                        let base_weight_index = self.ffm_weights_offset + left_hash.hash;
+                        let base_weight_index = left_hash.hash;
                         for j in 0..fc as usize {
                             let v = local_data_ffm.get_unchecked_mut(ifc + j);
                             v.index = base_weight_index + j as u32;
                             v.value = 0.0;
-                            _mm_prefetch(mem::transmute::<&f32, &i8>(&weights.get_unchecked(base_weight_index as usize + j).weight), _MM_HINT_T0);  // No benefit for now
+                            _mm_prefetch(mem::transmute::<&f32, &i8>(&ffm_weights.get_unchecked(base_weight_index as usize + j).weight), _MM_HINT_T0);  // No benefit for now
                        }
                        ifc += fc;
                     }
@@ -296,8 +298,8 @@ L: std::clone::Clone
                                 for k in 0..FFMK as usize {
                                     let llik = (left_local_index as usize + k) as usize;
                                     let rlik = (right_local_index as usize + k) as usize;
-                                    let left_hash_weight  = weights.get_unchecked((lindex+k) as usize).weight;
-                                    let right_hash_weight = weights.get_unchecked((rindex+k) as usize).weight;
+                                    let left_hash_weight  = ffm_weights.get_unchecked((lindex+k) as usize).weight;
+                                    let right_hash_weight = ffm_weights.get_unchecked((rindex+k) as usize).weight;
                                     
                                     let right_side = right_hash_weight * JOINT_VALUE;
                                     local_data_ffm.get_unchecked_mut(llik).value += right_side; // first derivate
@@ -313,6 +315,7 @@ L: std::clone::Clone
                 
                     });
                 }
+                }
                 // Trick: instead of multiply in the updates with learning rate, multiply the result
                 // vowpal compatibility
                 if wsum.is_nan() {
@@ -327,12 +330,14 @@ L: std::clone::Clone
                 prediction_probability = logistic(wsum);
 
                 // Weights are now writable, but local_data is read only
-                let weights = &mut self.weights;
-
+                
 
                 if update && fb.example_importance != 0.0 {
                     let general_gradient = (y - prediction_probability) * fb.example_importance;
         //            println!("General gradient: {}", general_gradient);
+
+                    {
+                    let weights = &mut self.weights;
 
                     for hashvalue in fb.lr_buffer.iter() {
         //A                _mm_prefetch(mem::transmute::<&f32, &i8>(&weights.get_unchecked((local_data_lr.get_unchecked(i+8)).index as usize).weight), _MM_HINT_T0);  // No benefit for now
@@ -345,14 +350,18 @@ L: std::clone::Clone
                         let update = self.optimizer_lr.calculate_update(gradient, &mut weights.get_unchecked_mut(feature_index).optimizer_data);
                         weights.get_unchecked_mut(feature_index).weight += update;
                     }
+                    }
+                    {                let ffm_weights = &mut self.weights[self.ffm_weights_offset as usize..];
+
                     
                     for i in 0..local_data_ffm_len {
         //                _mm_prefetch(mem::transmute::<&f32, &i8>(&weights.get_unchecked((local_data_ffm.get_unchecked(i+8)).index as usize).weight), _MM_HINT_T0);  // No benefit for now
                         let feature_value = local_data_ffm.get_unchecked(i).value;
                         let feature_index = local_data_ffm.get_unchecked(i).index as usize;
                         let gradient = general_gradient * feature_value;
-                        let update = self.optimizer_ffm.calculate_update(gradient, &mut weights.get_unchecked_mut(feature_index).optimizer_data);
-                        weights.get_unchecked_mut(feature_index).weight += update;
+                        let update = self.optimizer_ffm.calculate_update(gradient, &mut ffm_weights.get_unchecked_mut(feature_index).optimizer_data);
+                        ffm_weights.get_unchecked_mut(feature_index).weight += update;
+                    }
                     }
                 }
         


### PR DESCRIPTION
Two more optimizations of regressor, heavily benchmarket on skylake to provide benefits:
- take ffm_weights pointer and operate with it, instead of using offsets in first loop
- for ffm_local_data, separate out indices and values into two arrays... this in theory makes autovectorization easier for llvm

alltogether this brings +5% speed improvement