### PR TITLE
Regressor improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,9 @@ edition = "2018"
 
 [dependencies]
 csv = "1.1.3"
-fasthash = "0.4"
+# we need new version to enable static builds
+#fasthash = "0.4.0"
+fasthash = { git = "https://github.com/flier/rust-fasthash" }
 serde = {version = "1.0.114" , features = ["derive"]}
 serde_json = "1.0.55"
 #fastapprox = "0.3.0"

--- a/run_one.sh
+++ b/run_one.sh
@@ -19,8 +19,11 @@ vw=/home/minmax/minmax_old/zgit/vowpal_wabbit/vowpalwabbit/vw
 
 echo "target/release/fw $namespaces $rest -c -p f $fwonly "
 
-cargo build --release && \
-target/release/fw $namespaces $rest -c -p f $fwonly 
+cargo build --release --target x86_64-unknown-linux-musl --bin fw && \
+target/x86_64-unknown-linux-musl/release/fw $namespaces $rest -c -p f $fwonly 
+#cargo build --release --bin fw && \
+#target/release/fw $namespaces $rest -c -p f $fwonly 
+
 #&& time $vw $namespaces $rest -c -p v $vwonly 
 #clear; cargo build && target/debug/fw $namespaces $rest -p f && time vw $namespaces $rest -p v
 

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,5 @@
+
+
+// Maximum supported FFM embedding size 
+pub const FFM_MAX_K:usize = 128;
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,7 +27,7 @@ mod persistence;
 mod serving;
 mod optimizer;
 mod version;
-
+mod consts;
 //use crate::regressor::RegressorTrait;
 
 

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -8,7 +8,7 @@ use serde::{Serialize,Deserialize};//, Deserialize};
 use serde_json::{Value};
 
 use crate::vwmap;
-
+use crate::consts;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct FeatureComboDesc {
@@ -195,10 +195,16 @@ impl ModelInstance {
                 mi.ffm_fields.push(vec![index]);
             }
             mi.ffm_k = k_str.parse().expect("Number expected");
+            if mi.ffm_k > consts::FFM_MAX_K as u32{
+                return Err(Box::new(IOError::new(ErrorKind::Other, format!("Maximum ffm_k is: {}, passed: {}", consts::FFM_MAX_K, mi.ffm_k))))
+            }
         }
 
         if let Some(val) = cl.value_of("ffm_k") {
             mi.ffm_k = val.parse()?;
+            if mi.ffm_k > consts::FFM_MAX_K as u32{
+                return Err(Box::new(IOError::new(ErrorKind::Other, format!("Maximum ffm_k is: {}, passed: {}", consts::FFM_MAX_K, mi.ffm_k))))
+            }
         }        
 
         if let Some(val) = cl.value_of("ffm_init_center") {

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -238,9 +238,6 @@ L: std::clone::Clone
         unsafe {
         let y = fb.label; // 0.0 or 1.0
 
-        if y == feature_buffer::NO_LABEL as f32 {
-            panic!("Trying to learn from an example that has no label");
-        }
         let local_data_ffm_len = fb.ffm_buffer.len() * (self.ffm_k * fb.ffm_fields_count) as usize;
         
         macro_rules! core_macro {

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -16,6 +16,7 @@ use crate::feature_buffer;
 use crate::feature_buffer::HashAndValue;
 use crate::feature_buffer::HashAndValueAndSeq;
 use crate::optimizer;
+use crate::consts;
 use optimizer::OptimizerTrait;
 
 
@@ -65,14 +66,15 @@ pub struct ImmutableRegressor {
 
 
 macro_rules! specialize_k {
-    ( $input_expr:expr, 
-      $output_const:ident,
-      $code_block:block  ) => {
+    ( $input_expr: expr, 
+      $output_const: ident,
+      $wsumbuf: ident,
+      $code_block: block  ) => {
          match $input_expr {
-                2 => {const $output_const:u32 = 2; $code_block},
-                4 => {const $output_const:u32 = 4; $code_block},
-                8 => {const $output_const:u32 = 8; $code_block},
-                val => {let $output_const:u32 = val; $code_block},
+                2 => {const $output_const:u32 = 2;   let mut $wsumbuf: [f32;$output_const as usize] = [0.0;$output_const as usize]; $code_block},
+                4 => {const $output_const:u32 = 4;   let mut $wsumbuf: [f32;$output_const as usize] = [0.0;$output_const as usize]; $code_block},
+                8 => {const $output_const:u32 = 8;   let mut $wsumbuf: [f32;$output_const as usize] = [0.0;$output_const as usize]; $code_block},
+                val => {let $output_const:u32 = val; let mut $wsumbuf: [f32;consts::FFM_MAX_K] = [0.0;consts::FFM_MAX_K];      $code_block},
             }
     };
 }
@@ -236,6 +238,9 @@ L: std::clone::Clone
         unsafe {
         let y = fb.label; // 0.0 or 1.0
 
+        if y == feature_buffer::NO_LABEL as f32 {
+            panic!("Trying to learn from an example that has no label");
+        }
         let local_data_ffm_len = fb.ffm_buffer.len() * (self.ffm_k * fb.ffm_fields_count) as usize;
         
         macro_rules! core_macro {
@@ -273,8 +278,9 @@ L: std::clone::Clone
                        ifc += fc;
                     }
 
-                    specialize_k!(self.ffm_k, FFMK, {
+                    specialize_k!(self.ffm_k, FFMK, wsumbuf, {
                     let mut ifc:usize = 0;
+                    //let mut wsumbuf: [f32;8] = [0.0;8];
                     for (i, left_hash) in fb.ffm_buffer.iter().enumerate() {
                         let mut right_local_index = left_hash.contra_field_index as usize + ifc;
                         for right_hash in fb.ffm_buffer.get_unchecked(i+1 ..).iter() {
@@ -306,7 +312,10 @@ L: std::clone::Clone
                                     let right_side = right_hash_weight * JOINT_VALUE;
                                     *local_data_ffm_values.get_unchecked_mut(llik) += right_side; // first derivate
                                     *local_data_ffm_values.get_unchecked_mut(rlik) += left_hash_weight  * JOINT_VALUE; // first derivate
-                                    wsum += left_hash_weight * right_side;
+                    //                wsum += left_hash_weight * right_side;
+                                    // We do this, so in theory Rust/LLVM could vectorize whole loop
+                                    // Unfortunately it does not happen in practice, but we will get there
+                                    *wsumbuf.get_unchecked_mut(k) += left_hash_weight * right_side;
                                 }
                             });
                             
@@ -314,8 +323,11 @@ L: std::clone::Clone
                         ifc += fc;
                         
                     }
-                
+                    for k in 0..FFMK as usize {
+                        wsum += wsumbuf[k];
+                    }
                     });
+                    
                 }
                 // Trick: instead of multiply in the updates with learning rate, multiply the result
                 // vowpal compatibility
@@ -335,12 +347,10 @@ L: std::clone::Clone
 
                 if update && fb.example_importance != 0.0 {
                     let general_gradient = (y - prediction_probability) * fb.example_importance;
-        //            println!("General gradient: {}", general_gradient);
+                    //println!("General gradient: {}", general_gradient);
 
                     for hashvalue in fb.lr_buffer.iter() {
-        //A                _mm_prefetch(mem::transmute::<&f32, &i8>(&weights.get_unchecked((local_data_lr.get_unchecked(i+8)).index as usize).weight), _MM_HINT_T0);  // No benefit for now
-                        //let feature_value = local_data_lr.get_unchecked(i).value;
-                        //let feature_index = local_data_lr.get_unchecked(i).index as usize;
+        //                _mm_prefetch(mem::transmute::<&f32, &i8>(&weights.get_unchecked((local_data_lr.get_unchecked(i+8)).index as usize).weight), _MM_HINT_T0);  // No benefit for now
                         let feature_index     = hashvalue.hash as usize;
                         let feature_value:f32 = hashvalue.value;
                         


### PR DESCRIPTION
- start using multiple accumulators for doing wsum over embeddings, this in theory reduces instruction dependencies and allows rust to use avx (but it doesnt.. yet)
- specialize ffm_k in pure-prediction situation