### PR TITLE
Add an alignment check before calling slice::from_raw_parts

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -173,6 +173,9 @@ impl RecordCache {
         }
         unsafe { 
             // We're going to cast another view over the data, so we can read it as u32
+            // This requires that the allocator we're using gives us sufficiently-aligned bytes,
+            // but that's not guaranteed, so blow up to avoid UB if the allocator uses that freedom.
+            assert_eq!(self.byte_buffer.as_ptr() as usize % mem::align_of::<u32>(), 0);
             let buf_view:&[u32] = slice::from_raw_parts(self.byte_buffer.as_ptr() as *const u32, READBUF_LEN/4);
             loop {
                 // Classical buffer strategy:


### PR DESCRIPTION
A `Vec<u8>`'s buffer is only guaranteed to be 1-aligned, but it's used here in code assuming it's 4-aligned.  That might work, depending on what the allocator does, but it should be checked to avoid UB.

(Alternatively it could over-allocate the buffer and do something like [`align_to`](https://doc.rust-lang.org/nightly/std/primitive.slice.html#method.align_to), but I didn't want to make broad changes.)