### PR TITLE
Faster ffm

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,9 @@
+
+# February 2020
+- more than 15% speedup of FFM training
+- refactored Regressor to be more easily extendable
+- added "load_hogwile" command to serving mode. Enabling in-place
+replacement of the models
+
+# January 2020
+- fix truncated model when saving large >1Gb models

--- a/profile.sh
+++ b/profile.sh
@@ -1,5 +1,5 @@
 git clone git@github.com:brendangregg/FlameGraph.git
 git clone git@github.com:Yamakaky/rust-unmangle.git
 set -x
-perf record --call-graph dwarf,16384 -e cache-misses,cpu-clock -F 997 -- "$@" && perf script \
+perf record --call-graph dwarf,16384 -e cpu-clock -F 997 -- "$@" && perf script \
 | FlameGraph/stackcollapse-perf.pl | sed rust-unmangle/rust-unmangle | FlameGraph/flamegraph.pl > flame.svg && firefox flame.svg

--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -162,17 +162,25 @@ impl <L:OptimizerTrait + 'static> BlockTrait for BlockFFM<L>
                     let ffm_weights = &mut self.weights;
                     let fc = (fb.ffm_fields_count  * self.ffm_k) as usize;
                     let mut ifc:usize = 0;
-                    for i in 0..local_data_ffm_len {
+                    /*for i in 0..local_data_ffm_len {
                         *local_data_ffm_values.get_unchecked_mut(i) = 0.0;
+                    }*/
+                    for left_hash in &fb.ffm_buffer {
+                        for j in 0..fc as usize {
+                            *local_data_ffm_values.get_unchecked_mut(ifc + j) = 0.0;
+                            _mm_prefetch(mem::transmute::<&f32, &i8>(&ffm_weights.get_unchecked(left_hash.hash as usize + j).weight), _MM_HINT_T0);  // No benefit for now
+                       }
+                       ifc += fc;
                     }
+
                     
                     specialize_k!(self.ffm_k, FFMK, wsumbuf, {
-                        for left_hash in &fb.ffm_buffer {
+                   /*     for left_hash in &fb.ffm_buffer {
                           for j in 0..fb.ffm_buffer.len() {
                               _mm_prefetch(mem::transmute::<&f32, &i8>(&ffm_weights.get_unchecked(left_hash.hash as usize + j*FFMK as usize).weight), _MM_HINT_T0);  // No benefit for now
                           }
                         }
-                        
+                     */   
                         let mut ifc:usize = 0;
                         for (i, left_hash) in fb.ffm_buffer.iter().enumerate() {
                             let mut right_local_index = left_hash.contra_field_index as usize + ifc;

--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -165,7 +165,14 @@ impl <L:OptimizerTrait + 'static> BlockTrait for BlockFFM<L>
                     for i in 0..local_data_ffm_len {
                         *local_data_ffm_values.get_unchecked_mut(i) = 0.0;
                     }
+                    
                     specialize_k!(self.ffm_k, FFMK, wsumbuf, {
+                        for left_hash in &fb.ffm_buffer {
+                          for j in 0..fb.ffm_buffer.len() {
+                              _mm_prefetch(mem::transmute::<&f32, &i8>(&ffm_weights.get_unchecked(left_hash.hash as usize + j*FFMK as usize).weight), _MM_HINT_T0);  // No benefit for now
+                          }
+                        }
+                        
                         let mut ifc:usize = 0;
                         for (i, left_hash) in fb.ffm_buffer.iter().enumerate() {
                             let mut right_local_index = left_hash.contra_field_index as usize + ifc;


### PR DESCRIPTION
While working on more radical FFM optimization, I've noticed things were done in a very convoluted way with a needless temporary array involved.

Removal of that array and refactoring of code related to it leads to about 10% speed improvement of FFM part of the code in my tests both on server and on laptop.

This only applies to training code. No speedup in pure prediction mode.
