### PR TITLE
Fastpath for no-update (predict-only) case

### DIFF
--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -124,6 +124,9 @@ impl Regressor  {
             panic!("This regressor is immutable, you cannot call learn() with update = true");
         }
         let update:bool = update && (fb.example_importance != 0.0);
+        if !update { // Fast-path for no-update case
+            return self.predict(fb);
+        }
 
         let blocks_list = &mut self.blocks_boxes[..];
         let (current, further_blocks) = &mut blocks_list.split_at_mut(1);


### PR DESCRIPTION
When refactoring regressor,  I dropped the fastpath accidentially.

This again runs the fast-path for predict-only situations