### PR TITLE
discarding of temporary pointer as it may become invalid in case the vector is reallocated

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -99,7 +99,6 @@ impl VowpalParser {
 
             unsafe {
                 let p = self.tmp_read_buf.as_ptr();
-                let buf = self.output_buffer.as_mut_ptr();
                 let mut i_start:usize;
                 let mut i_end:usize = 0;
 
@@ -193,16 +192,16 @@ impl VowpalParser {
                         // -- and then just add feature to the end of the buffer
                         
                         if current_namespace_weight == 1.0 && feature_weight == 1.0 && current_char_num_of_features == 0 {
-                            *buf.add(current_char_index) = h;
+                            *self.output_buffer.as_mut_ptr().add(current_char_index) = h;
                         } else {
-                            if (current_char_num_of_features == 1) && (*buf.add(current_char_index) & IS_NOT_SINGLE_MASK) == 0 {
+                            if (current_char_num_of_features == 1) && (*self.output_buffer.as_ptr().add(current_char_index) & IS_NOT_SINGLE_MASK) == 0 {
                                 // We need to promote feature currently written in-place to out of place
-                                self.output_buffer.push(*buf.add(current_char_index));
+                                self.output_buffer.push(*self.output_buffer.as_ptr().add(current_char_index));
                                 self.output_buffer.push(FLOAT32_ONE);
                             }
                             self.output_buffer.push(h);
                             self.output_buffer.push((current_namespace_weight * feature_weight).to_bits());
-                            *buf.add(current_char_index) = IS_NOT_SINGLE_MASK | (((bufpos_namespace_start<<16) + self.output_buffer.len()) as u32);
+                            *self.output_buffer.as_mut_ptr().add(current_char_index) = IS_NOT_SINGLE_MASK | (((bufpos_namespace_start<<16) + self.output_buffer.len()) as u32);
                         }
                         current_char_num_of_features += 1;
                     }


### PR DESCRIPTION
while investigating some FW crashes due to segmentation fault, caused by malloc trying to allocate a block and complaining that the block CRC isn't the same as when it was freed,
I ran valgrind (on our reproducible setup offline) and got a hint that something bad is going on in some lines in parser.rs
the only thing I could imagine happening is the "buf" pointer somehow becoming invalid,
it seems this can happen if the output_buffer vec grows and is reallocated.
got rid of it - and the valgrind complaints went away, as well as the crashes.
still not sure exactly about the scenario though - because the vector is preallocated generously on startup,
so we might want to continue looking into the input as there may be something fishy going on there.
WDYT?