### PR TITLE
Add l2 regularization

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -79,7 +79,7 @@ pub fn parse<'a>() -> clap::ArgMatches<'a> {
                     .arg(Arg::with_name("l2")
                      .long("l2")
                      .value_name("0.0")
-                     .help("Regularization is not supported (only 0.0 will work)")
+                     .help("L2 regularization. Only supported for logistic regression blocks")
                      .takes_value(true))
 
                     .arg(Arg::with_name("sgd")

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -34,6 +34,7 @@ pub struct ModelInstance {
     #[serde(default = "default_f32_zero")]
     pub minimum_learning_rate: f32,
     pub power_t: f32,
+    pub l2: f32,        // Only supported for logistic regression blocks
     pub bit_precision: u8,
     pub hash_mask: u32,		// DEPRECATED, UNUSED -- this is recalculated in feature_buffer.rs
     pub add_constant_feature: bool,
@@ -101,6 +102,7 @@ impl ModelInstance {
             ffm_learning_rate: 0.5, // vw default
             minimum_learning_rate: 0.0, 
             bit_precision: 18,      // vw default
+            l2: 0.0,
             hash_mask: 0, // DEPRECATED, UNUSED
             power_t: 0.5,
             ffm_power_t: 0.5,
@@ -346,10 +348,7 @@ impl ModelInstance {
             }            
         }
         if let Some(val) = cl.value_of("l2") {
-            let v2:f32 = val.parse()?;
-            if v2.abs() > 0.00000001 {
-                return Err(Box::new(IOError::new(ErrorKind::Other, format!("--l2 can only be 0.0"))))
-            }
+            mi.l2 = val.parse()?;
         }
 
         if cl.is_present("noconstant") {


### PR DESCRIPTION
# Summary

This PR supports L2 regularization for logistic regression blocks. It's not quite the same kind of L2 regularization that VW uses, because we only apply regularization for the active weights.

# Alternative

It would be more complicated to implement applying L2 regularization to all weights with good time complexity. I don't fully understand VW, but I think they do L2 regularization as follows:

* For each weight, store the current sample index when the weight is updated
* When updating the weight, determine the number of L2 updates that were skipped using the current sample index and stored sample index
* Apply a big L2 update depending on the number of L2 updates that were skipped
* At the end of training, make a pass over all model weights and apply any pending L2 updates

If we want to do that instead, I'm OK with closing this PR.