### PR TITLE
Build cache only

### DIFF
--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -58,7 +58,7 @@ pub fn create_expected_args<'a>() -> App<'a, 'a> {
                       .long("build_cache_without_training")
                       .value_name("arg")
                       .help("Build cache file without training the first instance")
-                      .takes_value(true))
+                      .takes_value(false))
 
                     .arg(Arg::with_name("learning_rate")
                      .short("l")

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -54,6 +54,11 @@ pub fn create_expected_args<'a>() -> App<'a, 'a> {
                      .help("Adds single features")
                      .multiple(true)
                      .takes_value(true))
+                  .arg(Arg::with_name("build_cache_without_training")
+                      .long("build_cache_without_training")
+                      .value_name("arg")
+                      .help("Build cache file without training the first instance")
+                      .takes_value(true))
 
                     .arg(Arg::with_name("learning_rate")
                      .short("l")

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -54,10 +54,10 @@ pub fn create_expected_args<'a>() -> App<'a, 'a> {
                      .help("Adds single features")
                      .multiple(true)
                      .takes_value(true))
-                  .arg(Arg::with_name("build_cache_without_training")
+                  .arg(Arg::with_name("build_cache_only")
                       .long("build_cache_without_training")
                       .value_name("arg")
-                      .help("Build cache file without training the first instance")
+                      .help("Build cache file without training the first model instance")
                       .takes_value(false))
 
                     .arg(Arg::with_name("learning_rate")

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,10 +50,64 @@ fn main() {
     }
 }
 
+fn build_cache_without_training(cl: clap::ArgMatches) -> Result<(), Box<dyn Error>> {
+    // We'll parse once the command line into cl and then different objects will examine it
+    let input_filename = cl.value_of("data").expect("--data expected");
+    let vw_namespace_map_filepath = Path::new(input_filename)
+        .parent()
+        .expect("Couldn't access path given by --data")
+        .join("vw_namespace_map.csv");
+    let vw: vwmap::VwNamespaceMap;
+    vw = vwmap::VwNamespaceMap::new_from_csv_filepath(vw_namespace_map_filepath)?;
+    let mut cache = cache::RecordCache::new(input_filename, cl.is_present("cache"), &vw);
+    let input = File::open(input_filename)?;
+    let mut aa;
+    let mut bb;
+    let mut bufferred_input: &mut dyn BufRead = match input_filename.ends_with(".gz") {
+        true => {
+            aa = io::BufReader::new(MultiGzDecoder::new(input));
+            &mut aa
+        }
+        false => {
+            bb = io::BufReader::new(input);
+            &mut bb
+        }
+    };
+    let mut pa = parser::VowpalParser::new(&vw);
+    let mut example_num = 0;
+    loop {
+        let reading_result;
+        let buffer: &[u32];
+        if !cache.reading {
+            reading_result = pa.next_vowpal(&mut bufferred_input);
+            buffer = match reading_result {
+                Ok([]) => break, // EOF
+                Ok(buffer2) => buffer2,
+                Err(_e) => return Err(_e),
+            };
+            if cache.writing {
+                cache.push_record(buffer)?;
+            }
+        } else {
+            reading_result = cache.get_next_record();
+            buffer = match reading_result {
+                Ok([]) => break, // EOF
+                Ok(buffer) => buffer,
+                Err(_e) => return Err(_e),
+            };
+        }
+        example_num += 1;
+    }
+    cache.write_finish()?;
+    Ok(())
+}
+
 fn main2() -> Result<(), Box<dyn Error>> {
     // We'll parse once the command line into cl and then different objects will examine it
     let cl = cmdline::parse();
-
+    if cl.is_present("build_cache_without_training") {
+        return build_cache_without_training(cl)
+    }
     // Where will we be putting perdictions (if at all)
     let mut predictions_file = match cl.value_of("predictions") {
         Some(filename) => Some(BufWriter::new(File::create(filename)?)),

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ fn build_cache_without_training(cl: clap::ArgMatches) -> Result<(), Box<dyn Erro
         .join("vw_namespace_map.csv");
     let vw: vwmap::VwNamespaceMap;
     vw = vwmap::VwNamespaceMap::new_from_csv_filepath(vw_namespace_map_filepath)?;
-    let mut cache = cache::RecordCache::new(input_filename, cl.is_present("cache"), &vw);
+    let mut cache = cache::RecordCache::new(input_filename, true, &vw);
     let input = File::open(input_filename)?;
     let mut aa;
     let mut bb;

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,6 +51,8 @@ fn main() {
 }
 
 fn build_cache_without_training(cl: clap::ArgMatches) -> Result<(), Box<dyn Error>> {
+    /*! A method that enables creating the cache file without training the first model instance.
+    This is done in order to reduce building time of the cache and running the first model instance multi threaded. */
     // We'll parse once the command line into cl and then different objects will examine it
     let input_filename = cl.value_of("data").expect("--data expected");
     let vw_namespace_map_filepath = Path::new(input_filename)

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,1 +1,1 @@
-pub static LATEST: &str = "1.8";
+pub static LATEST: &str = "0.1";

--- a/src/vwmap.rs
+++ b/src/vwmap.rs
@@ -102,7 +102,7 @@ impl VwNamespaceMap {
         for (i, record_w) in rdr.records().enumerate() {
             let record = record_w?;
             let vwname_str = &record[0];
-            if vwname_str.as_bytes().len() != 1 {
+            if vwname_str.as_bytes().len() != 1 && i ==0 {
                 println!("Warning: multi-byte namespace names are not compatible with old style namespace arguments");
             }
             


### PR DESCRIPTION
create only cache file without training an instance in the process in order for a quick build and then multi threading the training instances