### PR TITLE
Ramzi's change to the dockerfile18 action

### DIFF
--- a/.github/workflows/docker-image-benchmark-u18.yml
+++ b/.github/workflows/docker-image-benchmark-u18.yml
@@ -1,3 +1,4 @@
+
 name: Build-docker-image-fw
 
 on:
@@ -13,8 +14,13 @@ jobs:
     runs-on: ubuntu-18.04
 
     steps:
+
     - uses: actions/checkout@v3
     - name: Branch name
-      run: echo running on branch ${GITHUB_HEAD_REF##*/}
+      env:
+        BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        GITHUB_REPOSITORY: ${{ github.event.repository.name }}
+      run: echo running on branch ${BRANCH_NAME} on ${GITHUB_REPOSITORY} name
+
     - name: Build the Docker image
-      run: docker build --build-arg FW_REPO_URL=https://github.com/$GITHUB_REPOSITORY.git --build-arg FW_BRANCH=${GITHUB_HEAD_REF##*/} . --file Dockerfile --tag fw-bench:$(date +%s)
+      run: docker build --build-arg FW_REPO_URL=https://github.com/$GITHUB_REPOSITORY.git --build-arg FW_BRANCH=${{ github.head_ref || github.ref_name }} . --file Dockerfile --tag fw-bench:$(date +%s)


### PR DESCRIPTION
The change enables tracking of branch names, including `main` (that was not the case before, yielding failed actions for main).