### PR TITLE
Use `if let` to deconstruct a single pattern, instead of `match`

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -51,10 +51,7 @@ impl<W: io::Write> Write for Wrapper<W> {
 }
 impl<W: Write> Drop for Wrapper<W> {
     fn drop(&mut self) {
-        match self.s.take() {
-            Some(s) => {let a = s.finish();}
-            None => {}
-        }
+        if let Some(s) = self.s.take() {let a = s.finish();}
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,12 +41,9 @@ mod version;
 mod vwmap;
 
 fn main() {
-    match main2() {
-        Err(e) => {
-            println!("Global error: {:?}", e);
-            std::process::exit(1)
-        }
-        Ok(()) => {}
+    if let Err(e) = main2() {
+        println!("Global error: {:?}", e);
+        std::process::exit(1)
     }
 }
 
@@ -119,22 +116,16 @@ fn main2() -> Result<(), Box<dyn Error>> {
     let testonly = cl.is_present("testonly");
 	
     let final_regressor_filename = cl.value_of("final_regressor");
-    match final_regressor_filename {
-        Some(filename) => {
-            if !cl.is_present("save_resume") {
-                return Err("You need to use --save_resume with --final_regressor, for vowpal wabbit compatibility")?;
-            }
-            println!("final_regressor = {}", filename);
+    if let Some(filename) = final_regressor_filename {
+        if !cl.is_present("save_resume") {
+            return Err("You need to use --save_resume with --final_regressor, for vowpal wabbit compatibility")?;
         }
-        None => {}
+        println!("final_regressor = {}", filename);
     };
 
     let inference_regressor_filename = cl.value_of("convert_inference_regressor");
-    match inference_regressor_filename {
-        Some(filename1) => {
-            println!("inference_regressor = {}", filename1);
-        }
-        None => {}
+    if let Some(filename1) = inference_regressor_filename {
+        println!("inference_regressor = {}", filename1);
     };
 
     /* setting up the pipeline, either from command line or from existing regressor */
@@ -155,11 +146,8 @@ fn main2() -> Result<(), Box<dyn Error>> {
             .expect("Convert mode requires --initial regressor");
         let (mut mi2, vw2, re_fixed) = persistence::new_regressor_from_filename(filename, true, Option::Some(&cl))?;
         mi2.optimizer = model_instance::Optimizer::SGD;
-        match inference_regressor_filename {
-            Some(filename1) => {
-                persistence::save_regressor_to_filename(filename1, &mi2, &vw2, re_fixed).unwrap()
-            }
-            None => {}
+        if let Some(filename1) = inference_regressor_filename {
+            persistence::save_regressor_to_filename(filename1, &mi2, &vw2, re_fixed).unwrap()
         }
     } else {
 		
@@ -269,9 +257,8 @@ fn main2() -> Result<(), Box<dyn Error>> {
             }
 
             if example_num > predictions_after {
-                match predictions_file.as_mut() {
-                    Some(file) => write!(file, "{:.6}\n", prediction)?,
-                    None => {}
+                if let Some(file) = predictions_file.as_mut() {
+                    write!(file, "{:.6}\n", prediction)?
                 }
             }
         }
@@ -280,11 +267,8 @@ fn main2() -> Result<(), Box<dyn Error>> {
         let elapsed = now.elapsed();
         println!("Elapsed: {:.2?} rows: {}", elapsed, example_num);
 
-        match final_regressor_filename {
-            Some(filename) => {
-                persistence::save_regressor_to_filename(filename, &mi, &vw, re).unwrap()
-            }
-            None => {}
+        if let Some(filename) = final_regressor_filename {
+            persistence::save_regressor_to_filename(filename, &mi, &vw, re).unwrap()
         }
     }
 

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -97,11 +97,8 @@ fn load_regressor_without_weights(
     let mut mi = model_instance::ModelInstance::new_from_buf(input_bufreader)
         .expect("Loading model instance from regressor failed");
 
-    match cmd_arguments {
-        Some(cmd_args) => {
-            model_instance::ModelInstance::update_hyperparameters_from_cmd(&cmd_args, &mut mi)?;
-        }
-        _ => (),
+    if let Some(cmd_args) = cmd_arguments {
+        model_instance::ModelInstance::update_hyperparameters_from_cmd(&cmd_args, &mut mi)?;
     }
 
     let mi = mi;


### PR DESCRIPTION
(Reposting #61 under a different branch name.)

Hi there,
I've recently started my rust journey and was hoping you'd be open for some ornamental changes recommended by clippy.

This PR replaces `match ... Some(...)` blocks with the more idiomatic `if let`. 