### PR TITLE
Logging interface + some cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ flate2 = { version = "1.0", features = ["cloudflare_zlib"], default-features = f
 shellwords = "1.1.0"
 blas = "0.22"
 intel-mkl-src = {version= "0.7.0", default-features = false, features=["download", "mkl-static-lp64-seq"]}
+log = "0.4"
+env_logger = "0.10.0"
 
 [build-dependencies]
 cbindgen = "0.23.0"

--- a/src/block_loss_functions.rs
+++ b/src/block_loss_functions.rs
@@ -8,7 +8,7 @@ use crate::model_instance;
 use crate::port_buffer;
 use crate::regressor;
 use regressor::BlockTrait;
-use log::{warn};
+use log::{warn, error};
 
 //use fastapprox::fast::sigmoid; // surprisingly this doesn't work very well
 
@@ -118,7 +118,7 @@ impl BlockTrait for BlockSigmoid {
             let mut general_gradient: f32;
 
             if wsum.is_nan() {
-                warn!(
+                error!(
                     "NAN prediction in example {}, forcing 0.0",
                     fb.example_number
                 );

--- a/src/block_loss_functions.rs
+++ b/src/block_loss_functions.rs
@@ -7,7 +7,6 @@ use crate::graph;
 use crate::model_instance;
 use crate::port_buffer;
 use crate::regressor;
-use log::{error, warn};
 use regressor::BlockTrait;
 
 //use fastapprox::fast::sigmoid; // surprisingly this doesn't work very well
@@ -118,7 +117,7 @@ impl BlockTrait for BlockSigmoid {
             let mut general_gradient: f32;
 
             if wsum.is_nan() {
-                error!(
+                log::error!(
                     "NAN prediction in example {}, forcing 0.0",
                     fb.example_number
                 );
@@ -168,7 +167,7 @@ impl BlockTrait for BlockSigmoid {
 
             let prediction_probability: f32;
             if wsum.is_nan() {
-                warn!(
+                log::warn!(
                     "NAN prediction in example {}, forcing 0.0",
                     fb.example_number
                 );

--- a/src/block_loss_functions.rs
+++ b/src/block_loss_functions.rs
@@ -7,8 +7,8 @@ use crate::graph;
 use crate::model_instance;
 use crate::port_buffer;
 use crate::regressor;
+use log::{error, warn};
 use regressor::BlockTrait;
-use log::{warn, error};
 
 //use fastapprox::fast::sigmoid; // surprisingly this doesn't work very well
 

--- a/src/block_loss_functions.rs
+++ b/src/block_loss_functions.rs
@@ -8,6 +8,7 @@ use crate::model_instance;
 use crate::port_buffer;
 use crate::regressor;
 use regressor::BlockTrait;
+use log::{warn};
 
 //use fastapprox::fast::sigmoid; // surprisingly this doesn't work very well
 
@@ -117,7 +118,7 @@ impl BlockTrait for BlockSigmoid {
             let mut general_gradient: f32;
 
             if wsum.is_nan() {
-                eprintln!(
+                warn!(
                     "NAN prediction in example {}, forcing 0.0",
                     fb.example_number
                 );
@@ -133,7 +134,7 @@ impl BlockTrait for BlockSigmoid {
                 prediction_probability = logistic(wsum);
                 general_gradient = -(fb.label - prediction_probability) * fb.example_importance;
             }
-            //println!("General gradient: {}", general_gradient);
+
             *pb.tape.get_unchecked_mut(self.output_offset) = prediction_probability;
             if self.copy_to_result {
                 pb.observations.push(prediction_probability);
@@ -167,7 +168,7 @@ impl BlockTrait for BlockSigmoid {
 
             let prediction_probability: f32;
             if wsum.is_nan() {
-                eprintln!(
+                warn!(
                     "NAN prediction in example {}, forcing 0.0",
                     fb.example_number
                 );

--- a/src/block_misc.rs
+++ b/src/block_misc.rs
@@ -29,7 +29,6 @@ pub fn new_observe_block(
     replace_backward_with: Option<f32>,
 ) -> Result<graph::BlockPtrOutput, Box<dyn Error>> {
     let num_inputs = bg.get_num_output_values(vec![&input]);
-    //    println!("Inputs: {} vec: {:?}", num_inputs, input);
     let block = Box::new(BlockObserve {
         num_inputs: num_inputs as usize,
         input_offset: usize::MAX,
@@ -823,10 +822,7 @@ impl BlockTrait for BlockTriangle {
 
             let mut output_index: usize = 0;
             for i in 0..self.square_width {
-                //                    println!("AAAAA i: {}", i);
                 for j in 0..i {
-                    //                        let input = input_tape.get_unchecked(i * self.square_width + j);
-                    //                       println!("Output index: i: {}, j: {}, A: {}, B: {}", i, j, input_tape[i * self.square_width + j], input_tape[j * self.square_width + i]);
                     *output_tape.get_unchecked_mut(output_index) =
                         *input_tape.get_unchecked(i * self.square_width + j) * 2.0;
                     output_index += 1;

--- a/src/block_neural.rs
+++ b/src/block_neural.rs
@@ -653,5 +653,4 @@ mod tests {
 
         assert_epsilon!(slearn2(&mut bg, &fb, &mut pb, false), 1.5);
     }
-
 }

--- a/src/block_neural.rs
+++ b/src/block_neural.rs
@@ -380,7 +380,6 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockNeuronLayer<L> {
                         if self.dropout != 0.0
                             && *self.rng_scratchpad.get_unchecked(j) < self.dropout_threshold
                         {
-                            //          println!("B:j {}", j);
                             continue;
                         }
 
@@ -655,97 +654,4 @@ mod tests {
         assert_epsilon!(slearn2(&mut bg, &fb, &mut pb, false), 1.5);
     }
 
-    // #[test]
-    // fn test_neuron() {
-    //     let mut mi = model_instance::ModelInstance::new_empty().unwrap();
-    //     mi.nn_learning_rate = 0.1;
-    //     mi.nn_power_t = 0.0;
-    //     mi.nn_init_acc_gradient = mi.init_acc_gradient;
-    //     mi.optimizer = Optimizer::SGD;
-
-    //     let mut bg = BlockGraph::new();
-    //     let input_block = block_misc::new_const_block(&mut bg, vec![2.0]).unwrap();
-    //     let neuron_block = new_neuron_block(&mut bg, &mi, input_block, NeuronType::WeightedSum, InitType::One).unwrap();
-    //     let observe_block = block_misc::new_observe_block(&mut bg, neuron_block, Observe::Forward, Some(1.0)).unwrap();
-    //     bg.finalize();
-    //     bg.allocate_and_init_weights(&mi);
-
-    //     let mut pb = bg.new_port_buffer();
-    //     let fb = fb_vec();
-    //     assert_epsilon!(slearn2  (&mut bg, &fb, &mut pb, true), 2.0);
-    //     assert_eq!(pb.observations.len(), 1);
-    //     assert_epsilon!(slearn2  (&mut bg, &fb, &mut pb, true), 1.5);
-    // }
-    /*
-        #[test]
-        fn test_dropout() {
-            let mut mi = model_instance::ModelInstance::new_empty().unwrap();
-
-            let NUM_NEURONS = 6;
-            let mut bg = BlockGraph::new();
-            let input_block = block_misc::new_const_block(&mut bg, vec![3.0]).unwrap();
-            let observe_block_backward = block_misc::new_observe_block(&mut bg, input_block, Observe::Backward, None).unwrap();
-            let neuron_block = new_neuronlayer_block(&mut bg,
-                                                &mi,
-                                                observe_block_backward,
-                                                NeuronType::WeightedSum,
-                                                NUM_NEURONS,
-                                                InitType::One,
-                                                0.5, // dropout
-                                                0.0, // max norm
-                                                false,
-                                                ).unwrap();
-            let observe_block = block_misc::new_observe_block(&mut bg, neuron_block, Observe::Forward, Some(3.0)).unwrap();
-            bg.finalize();
-            bg.allocate_and_init_weights(&mi);
-
-            let mut pb = bg.new_port_buffer();
-
-            let fb = fb_vec();
-
-            spredict2  (&mut bg, &fb, &mut pb, false);
-            assert_eq!(pb.observations, vec![3.0, 3.0, 3.0, 3.0, 3.0, 3.0, // mostly deterministic due to specific PRNG use,
-                                            3.0 			       // Untouched output when forward-only
-                                                        ]);
-
-            slearn2  (&mut bg, &fb, &mut pb, true);
-            assert_eq!(pb.observations, vec![6.0, 0.0, 0.0, 0.0, 6.0, 6.0, // mostly deterministic due to specific PRNG use
-                                            18.0 			       // scaled backprop
-                                                        ]);
-    //        println!("O: {:?}", pb.observations);
-
-
-
-        }
-
-    */
-
-    /*    #[test]
-        fn test_segm() {
-            unsafe {
-            let input_matrix:Vec<f32> = vec![1.0, 2.0,
-                                             3.0, 4.0,
-                                             5.0, 6.0];
-            let input_vec: Vec<f32> = vec![2.0, 1.0];
-            let mut output_vec : Vec<f32> = vec![0.0, 0.0, 0.0];
-
-                        sgemv(
-                         b'T',//   trans: u8,
-                         2, //   m: i32,          // num_neurons
-                         3, //   n: i32, 	      // num inputs
-                         1.0, //   alpha: f32,
-                         &input_matrix, //  a: &[f32],
-                         2,   //lda: i32,
-                         &input_vec,//   x: &[f32],
-                            1, //incx: i32,
-                            1.0, // beta: f32,
-                            &mut output_vec, //y: &mut [f32],
-                            1,//incy: i32
-                        );
-
-        println!("Output : {:?}", output_vec);
-
-        }
-        }
-    */
 }

--- a/src/block_normalize.rs
+++ b/src/block_normalize.rs
@@ -120,7 +120,6 @@ impl BlockTrait for BlockNormalize {
         debug_assert!(self.num_inputs > 0);
 
         unsafe {
-
             let mut mean: f32 = 0.0;
             for i in 0..self.num_inputs as usize {
                 mean += *pb.tape.get_unchecked_mut(self.input_offset + i);

--- a/src/block_normalize.rs
+++ b/src/block_normalize.rs
@@ -92,9 +92,7 @@ impl BlockTrait for BlockNormalize {
             variance /= self.num_inputs as f32;
             variance = variance.sqrt();
 
-            //            println!("var1: {}, var2: {}, sum: {}, sumsqr: {}", var1, var2, sum, sumsqr);
             let variance_inv = 1.0 / variance;
-            //            let avg = sum / self.num_inputs as f32;
 
             for i in 0..self.num_inputs {
                 *pb.tape.get_unchecked_mut(self.output_offset + i) =
@@ -122,19 +120,7 @@ impl BlockTrait for BlockNormalize {
         debug_assert!(self.num_inputs > 0);
 
         unsafe {
-            /*            let mut sum: f32 = 0.0;
-                        let mut sumsqr: f32 = 0.0;
-                        let K = 1.0;
-                        for i in 0..self.num_inputs as usize {
-                                let w = *pb.tape.get_unchecked_mut(self.input_offset + i) - K;
-                                sum += w;
-                                sumsqr += w * w;
-                        }
-                        let var1 = (sumsqr - sum*sum/self.num_inputs as f32) /
-                                        self.num_inputs as f32 + EPS;
-                        let var2 = var1.sqrt();
-            //            println!("var1: {}, var2: {}, sum: {}, sumsqr: {}", var1, var2, sum, sumsqr);
-            */
+
             let mut mean: f32 = 0.0;
             for i in 0..self.num_inputs as usize {
                 mean += *pb.tape.get_unchecked_mut(self.input_offset + i);

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,4 @@
+use log::{info, warn};
 use std::error::Error;
 use std::fs;
 use std::io;
@@ -5,7 +6,6 @@ use std::io::Read;
 use std::io::Write;
 use std::path;
 use std::{mem, slice};
-use log::{info, warn};
 //use flate2::write::DeflateEncoder;
 //use flate2::Compression;
 //use flate2::read::DeflateDecoder;
@@ -106,7 +106,6 @@ impl RecordCache {
                     // we buffer ourselves, otherwise i would be wise to use bufreader
                     rc.input_bufreader = Box::new(fs::File::open(&final_filename).unwrap());
                 } else {
-
                     rc.input_bufreader = Box::new(
                         lz4::Decoder::new(fs::File::open(&final_filename).unwrap()).unwrap(),
                     );

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,3 @@
-use log::{info, warn};
 use std::error::Error;
 use std::fs;
 use std::io;
@@ -110,12 +109,12 @@ impl RecordCache {
                         lz4::Decoder::new(fs::File::open(&final_filename).unwrap()).unwrap(),
                     );
                 }
-                info!("using cache_file = {}", final_filename);
-                info!("ignoring text input in favor of cache input");
+                log::info!("using cache_file = {}", final_filename);
+                log::info!("ignoring text input in favor of cache input");
                 match rc.verify_header(vw_map) {
                     Ok(()) => {}
                     Err(e) => {
-                        warn!("Couldn't use the existing cache file: {:?}", e);
+                        log::error!("Couldn't use the existing cache file: {:?}", e);
                         rc.reading = false;
                     }
                 }
@@ -124,7 +123,7 @@ impl RecordCache {
 
             if !rc.reading {
                 rc.writing = true;
-                info!("creating cache file = {}", final_filename);
+                log::info!("creating cache file = {}", final_filename);
                 if !gz {
                     rc.output_bufwriter = Box::new(io::BufWriter::new(
                         fs::File::create(temporary_filename).unwrap(),

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,6 +5,7 @@ use std::io::Read;
 use std::io::Write;
 use std::path;
 use std::{mem, slice};
+use log::{info, warn};
 //use flate2::write::DeflateEncoder;
 //use flate2::Compression;
 //use flate2::read::DeflateDecoder;
@@ -105,17 +106,17 @@ impl RecordCache {
                     // we buffer ourselves, otherwise i would be wise to use bufreader
                     rc.input_bufreader = Box::new(fs::File::open(&final_filename).unwrap());
                 } else {
-                    //                    rc.input_bufreader = Box::new(zstd::stream::Decoder::new(fs::File::open(&final_filename).unwrap()).unwrap());
+
                     rc.input_bufreader = Box::new(
                         lz4::Decoder::new(fs::File::open(&final_filename).unwrap()).unwrap(),
                     );
                 }
-                println!("using cache_file = {}", final_filename);
-                println!("ignoring text input in favor of cache input");
+                info!("using cache_file = {}", final_filename);
+                info!("ignoring text input in favor of cache input");
                 match rc.verify_header(vw_map) {
                     Ok(()) => {}
                     Err(e) => {
-                        println!("Couldn't use the existing cache file: {:?}", e);
+                        warn!("Couldn't use the existing cache file: {:?}", e);
                         rc.reading = false;
                     }
                 }
@@ -124,7 +125,7 @@ impl RecordCache {
 
             if !rc.reading {
                 rc.writing = true;
-                println!("creating cache file = {}", final_filename);
+                info!("creating cache file = {}", final_filename);
                 if !gz {
                     rc.output_bufwriter = Box::new(io::BufWriter::new(
                         fs::File::create(temporary_filename).unwrap(),

--- a/src/feature_buffer.rs
+++ b/src/feature_buffer.rs
@@ -2,7 +2,7 @@ use crate::feature_transform_executor;
 use crate::model_instance;
 use crate::parser;
 use crate::vwmap::{NamespaceFormat, NamespaceType};
-use log::{info};
+use log::info;
 
 const VOWPAL_FNV_PRIME: u32 = 16777619; // vowpal magic number
                                         //const CONSTANT_NAMESPACE:usize = 128;

--- a/src/feature_buffer.rs
+++ b/src/feature_buffer.rs
@@ -2,7 +2,6 @@ use crate::feature_transform_executor;
 use crate::model_instance;
 use crate::parser;
 use crate::vwmap::{NamespaceFormat, NamespaceType};
-use log::info;
 
 const VOWPAL_FNV_PRIME: u32 = 16777619; // vowpal magic number
                                         //const CONSTANT_NAMESPACE:usize = 128;
@@ -175,7 +174,7 @@ impl FeatureBufferTranslator {
     }
 
     pub fn print(&self) -> () {
-        info!("item out {:?}", self.feature_buffer.lr_buffer);
+        log::info!("item out {:?}", self.feature_buffer.lr_buffer);
     }
 
     pub fn translate(&mut self, record_buffer: &[u32], example_number: u64) -> () {

--- a/src/feature_buffer.rs
+++ b/src/feature_buffer.rs
@@ -2,6 +2,7 @@ use crate::feature_transform_executor;
 use crate::model_instance;
 use crate::parser;
 use crate::vwmap::{NamespaceFormat, NamespaceType};
+use log::{info};
 
 const VOWPAL_FNV_PRIME: u32 = 16777619; // vowpal magic number
                                         //const CONSTANT_NAMESPACE:usize = 128;
@@ -174,7 +175,7 @@ impl FeatureBufferTranslator {
     }
 
     pub fn print(&self) -> () {
-        println!("item out {:?}", self.feature_buffer.lr_buffer);
+        info!("item out {:?}", self.feature_buffer.lr_buffer);
     }
 
     pub fn translate(&mut self, record_buffer: &[u32], example_number: u64) -> () {
@@ -491,7 +492,7 @@ mod tests {
             parser::NO_FEATURES,
         ]);
         fbt.translate(&rb, 0);
-        //        println!("out {}, out mod 2^24 {}", fbt.feature_buffer.lr_buffer[1], fbt.feature_buffer.lr_buffer[1] & ((1<<24)-1));
+
         assert_eq!(
             fbt.feature_buffer.lr_buffer,
             vec![HashAndValue {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,10 +1,10 @@
+use crate::block_misc;
 use crate::model_instance;
 use crate::port_buffer;
 use crate::regressor::BlockTrait;
+use log::info;
 use std::error::Error;
 use std::mem;
-use log::{info};
-use crate::block_misc;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct OutputSlot(usize);
@@ -523,7 +523,6 @@ mod tests {
                 .downcast_mut::<block_misc::BlockCopy>()
                 .unwrap();
             assert!(copy_block_1.input_offset != copy_block_1.output_offsets[0]);
-
         }
         {
             // But second one can re-use the input as output
@@ -532,7 +531,6 @@ mod tests {
                 .downcast_mut::<block_misc::BlockCopy>()
                 .unwrap();
             assert!(copy_block_2.input_offset == copy_block_2.output_offsets[0]);
-
         }
     }
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -2,7 +2,6 @@ use crate::block_misc;
 use crate::model_instance;
 use crate::port_buffer;
 use crate::regressor::BlockTrait;
-use log::info;
 use std::error::Error;
 use std::mem;
 
@@ -171,7 +170,7 @@ impl BlockGraph {
     }
 
     pub fn println(&self) {
-        info!("Graph nodes:\n");
+        log::info!("Graph nodes:\n");
         for n in self.nodes.iter() {
             println!("  {:?}", n);
         }

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -3,7 +3,7 @@ use crate::port_buffer;
 use crate::regressor::BlockTrait;
 use std::error::Error;
 use std::mem;
-
+use log::{info};
 use crate::block_misc;
 
 #[derive(Copy, Clone, Debug, PartialEq)]
@@ -171,7 +171,7 @@ impl BlockGraph {
     }
 
     pub fn println(&self) {
-        println!("Graph nodes:\n");
+        info!("Graph nodes:\n");
         for n in self.nodes.iter() {
             println!("  {:?}", n);
         }
@@ -334,9 +334,7 @@ mod tests {
         let output_node =
             block_misc::new_observe_block(&mut bg, const_block_output, Observe::Forward, Some(1.0))
                 .unwrap();
-        //        assert_eq!(output_node, ());
-        //        println!("Output nodes: {:?}", output_nodes);
-        //println!("Block 0: edges_in: {:?}, edges_out: {:?}", bg.edges_in[0], bg.edges_out[0]);
+
         assert_eq!(bg.nodes[0].edges_in, vec![]); // basically []
         assert_eq!(
             bg.nodes[0].edges_out,
@@ -368,9 +366,7 @@ mod tests {
         // Let's add one result block
         let output_node =
             block_misc::new_observe_block(&mut bg, c1, Observe::Forward, Some(1.0)).unwrap();
-        //        assert_eq!(output_node, ());
-        //        println!("Output nodes: {:?}", output_nodes);
-        //println!("Block 0: edges_in: {:?}, edges_out: {:?}", bg.edges_in[0], bg.edges_out[0]);
+
         assert_eq!(bg.nodes[0].edges_in.len(), 0);
         assert_eq!(
             bg.nodes[0].edges_out,
@@ -527,7 +523,7 @@ mod tests {
                 .downcast_mut::<block_misc::BlockCopy>()
                 .unwrap();
             assert!(copy_block_1.input_offset != copy_block_1.output_offsets[0]);
-            //          println!("C1: input {} outputs: {:?}", copy_block_1.input_offset, copy_block_1.output_offsets);
+
         }
         {
             // But second one can re-use the input as output
@@ -536,7 +532,7 @@ mod tests {
                 .downcast_mut::<block_misc::BlockCopy>()
                 .unwrap();
             assert!(copy_block_2.input_offset == copy_block_2.output_offsets[0]);
-            //          println!("C2: input {} outputs: {:?}", copy_block_2.input_offset, copy_block_2.output_offsets);
+
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@ mod feature_transform_executor;
 mod feature_transform_implementations;
 mod feature_transform_parser;
 mod graph;
+mod logging_layer;
 mod model_instance;
 mod multithread_helpers;
 mod optimizer;
@@ -69,6 +70,8 @@ pub extern "C" fn new_fw_predictor_prototype(command: *const c_char) -> *mut Ffi
     // create a "prototype" predictor that loads the weights file. This predictor is expensive, and is intended
     // to only be created once. If additional predictors are needed (e.g. for concurrent work), please
     // use this "prototype" with the clone_lite function, which will create cheap copies
+    logging_layer::initialize_logging_layer();
+
     let str_command = c_char_to_str(command);
     let words = shellwords::split(str_command).unwrap();
     let cmd_matches = cmdline::create_expected_args().get_matches_from(words);

--- a/src/logging_layer.rs
+++ b/src/logging_layer.rs
@@ -8,6 +8,9 @@ pub fn initialize_logging_layer() {
         "info" => builder.filter_level(log::LevelFilter::Info),
         "warn" => builder.filter_level(log::LevelFilter::Warn),
         "error" => builder.filter_level(log::LevelFilter::Error),
+	"trace" => builder.filter_level(log::LevelFilter::Trace),
+	"debug" => builder.filter_level(log::LevelFilter::Debug),
+	"off" => builder.filter_level(log::LevelFilter::Off),
         _ => builder.filter_level(log::LevelFilter::Info),
     };
     builder.init();

--- a/src/logging_layer.rs
+++ b/src/logging_layer.rs
@@ -1,0 +1,14 @@
+extern crate log;
+use env_logger::Builder;
+
+pub fn initialize_logging_layer() {
+    let mut builder = Builder::new();
+    let log_level = std::env::var("LOG_LEVEL").unwrap_or_else(|_| "info".to_string());
+    match log_level.to_lowercase().as_str() {
+        "info" => builder.filter_level(log::LevelFilter::Info),
+        "warn" => builder.filter_level(log::LevelFilter::Warn),
+        "error" => builder.filter_level(log::LevelFilter::Error),
+        _ => builder.filter_level(log::LevelFilter::Info),
+    };
+    builder.init();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,7 +22,6 @@ extern crate intel_mkl_src;
 extern crate log;
 
 use env_logger::Builder;
-use log::{info, warn, LevelFilter};
 
 #[macro_use]
 extern crate nom;
@@ -54,11 +53,11 @@ mod version;
 mod vwmap;
 
 fn main() {
-    Builder::new().filter_level(LevelFilter::max()).init();
+    Builder::new().filter_level(log::LevelFilter::max()).init();
 
     match main2() {
         Err(e) => {
-            warn!("Global error: {:?}", e);
+            log::error!("Global error: {:?}", e);
             std::process::exit(1)
         }
         Ok(()) => {}
@@ -139,7 +138,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
             if !cl.is_present("save_resume") {
                 return Err("You need to use --save_resume with --final_regressor, for vowpal wabbit compatibility")?;
             }
-            info!("final_regressor = {}", filename);
+            log::info!("final_regressor = {}", filename);
         }
         None => {}
     };
@@ -147,7 +146,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
     let inference_regressor_filename = cl.value_of("convert_inference_regressor");
     match inference_regressor_filename {
         Some(filename1) => {
-            info!("inference_regressor = {}", filename1);
+            log::info!("inference_regressor = {}", filename1);
         }
         None => {}
     };
@@ -159,7 +158,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
         let filename = cl
             .value_of("initial_regressor")
             .expect("Daemon mode only supports serving from --initial regressor");
-        info!("initial_regressor = {}", filename);
+        log::info!("initial_regressor = {}", filename);
         let (mi2, vw2, re_fixed) =
             persistence::new_regressor_from_filename(filename, true, Option::Some(&cl))?;
 
@@ -184,7 +183,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
         let mi: model_instance::ModelInstance;
 
         if let Some(filename) = cl.value_of("initial_regressor") {
-            info!("initial_regressor = {}", filename);
+            log::info!("initial_regressor = {}", filename);
             (mi, vw, re) =
                 persistence::new_regressor_from_filename(filename, testonly, Option::Some(&cl))?;
         } else {
@@ -293,7 +292,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
         cache.write_finish()?;
 
         let elapsed = now.elapsed();
-        info!("Elapsed: {:.2?} rows: {}", elapsed, example_num);
+        log::info!("Elapsed: {:.2?} rows: {}", elapsed, example_num);
 
         match final_regressor_filename {
             Some(filename) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,11 @@ use std::time::Instant;
 
 extern crate blas;
 extern crate intel_mkl_src;
+extern crate log;
+
+
+use log::{info, warn, LevelFilter};
+use env_logger::Builder;
 
 #[macro_use]
 extern crate nom;
@@ -50,9 +55,12 @@ mod version;
 mod vwmap;
 
 fn main() {
+
+    Builder::new().filter_level(LevelFilter::max()).init();
+    
     match main2() {
         Err(e) => {
-            println!("Global error: {:?}", e);
+            warn!("Global error: {:?}", e);
             std::process::exit(1)
         }
         Ok(()) => {}
@@ -133,7 +141,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
             if !cl.is_present("save_resume") {
                 return Err("You need to use --save_resume with --final_regressor, for vowpal wabbit compatibility")?;
             }
-            println!("final_regressor = {}", filename);
+            info!("final_regressor = {}", filename);
         }
         None => {}
     };
@@ -141,7 +149,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
     let inference_regressor_filename = cl.value_of("convert_inference_regressor");
     match inference_regressor_filename {
         Some(filename1) => {
-            println!("inference_regressor = {}", filename1);
+            info!("inference_regressor = {}", filename1);
         }
         None => {}
     };
@@ -153,7 +161,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
         let filename = cl
             .value_of("initial_regressor")
             .expect("Daemon mode only supports serving from --initial regressor");
-        println!("initial_regressor = {}", filename);
+        info!("initial_regressor = {}", filename);
         let (mi2, vw2, re_fixed) =
             persistence::new_regressor_from_filename(filename, true, Option::Some(&cl))?;
 
@@ -178,7 +186,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
         let mi: model_instance::ModelInstance;
 
         if let Some(filename) = cl.value_of("initial_regressor") {
-            println!("initial_regressor = {}", filename);
+            info!("initial_regressor = {}", filename);
             (mi, vw, re) =
                 persistence::new_regressor_from_filename(filename, testonly, Option::Some(&cl))?;
         } else {
@@ -287,7 +295,7 @@ fn main2() -> Result<(), Box<dyn Error>> {
         cache.write_finish()?;
 
         let elapsed = now.elapsed();
-        println!("Elapsed: {:.2?} rows: {}", elapsed, example_num);
+        info!("Elapsed: {:.2?} rows: {}", elapsed, example_num);
 
         match final_regressor_filename {
             Some(filename) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,9 +21,8 @@ extern crate blas;
 extern crate intel_mkl_src;
 extern crate log;
 
-
-use log::{info, warn, LevelFilter};
 use env_logger::Builder;
+use log::{info, warn, LevelFilter};
 
 #[macro_use]
 extern crate nom;
@@ -55,9 +54,8 @@ mod version;
 mod vwmap;
 
 fn main() {
-
     Builder::new().filter_level(LevelFilter::max()).init();
-    
+
     match main2() {
         Err(e) => {
             warn!("Global error: {:?}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,9 +19,6 @@ use std::time::Instant;
 
 extern crate blas;
 extern crate intel_mkl_src;
-extern crate log;
-
-use env_logger::Builder;
 
 #[macro_use]
 extern crate nom;
@@ -41,6 +38,7 @@ mod feature_transform_executor;
 mod feature_transform_implementations;
 mod feature_transform_parser;
 mod graph;
+mod logging_layer;
 mod model_instance;
 mod multithread_helpers;
 mod optimizer;
@@ -53,7 +51,7 @@ mod version;
 mod vwmap;
 
 fn main() {
-    Builder::new().filter_level(log::LevelFilter::max()).init();
+    logging_layer::initialize_logging_layer();
 
     match main2() {
         Err(e) => {

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -9,6 +9,7 @@ use crate::consts;
 use crate::feature_transform_parser;
 use crate::vwmap;
 use crate::vwmap::NamespaceDescriptor;
+use log::{warn};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct FeatureComboDesc {
@@ -387,7 +388,6 @@ impl ModelInstance {
             for namespaces_str in in_v {
                 let mut field: Vec<vwmap::NamespaceDescriptor> = Vec::new();
                 for char in namespaces_str.chars() {
-                    //println!("K: {}", char);
                     let namespace_descriptor = feature_transform_parser::get_namespace_descriptor(
                         &mi.transform_namespaces,
                         vw,
@@ -541,7 +541,8 @@ impl ModelInstance {
         }
 
         for (hyper_name, hyper_value) in replacement_hyperparam_ids.into_iter() {
-            println!(
+	    
+            warn!(
                 "Warning! Updated hyperparameter {} to value {}",
                 hyper_name, hyper_value
             );
@@ -682,7 +683,6 @@ C,featureC
         }
         assert!(mi.parse_nn("1:foo:bar").is_ok());
         assert!(mi.parse_nn("0::").is_ok());
-        //        println!("AAA: {:?}", mi.nn_config.layers);
         assert_eq!(mi.nn_config.layers[0].get("").unwrap(), "");
         assert_eq!(mi.nn_config.layers[1].get("foo").unwrap(), "bar");
         assert_eq!(mi.nn_config.layers[2].len(), 0);

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -9,7 +9,7 @@ use crate::consts;
 use crate::feature_transform_parser;
 use crate::vwmap;
 use crate::vwmap::NamespaceDescriptor;
-use log::{warn};
+use log::warn;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct FeatureComboDesc {
@@ -541,7 +541,6 @@ impl ModelInstance {
         }
 
         for (hyper_name, hyper_value) in replacement_hyperparam_ids.into_iter() {
-	    
             warn!(
                 "Warning! Updated hyperparameter {} to value {}",
                 hyper_name, hyper_value

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -9,7 +9,6 @@ use crate::consts;
 use crate::feature_transform_parser;
 use crate::vwmap;
 use crate::vwmap::NamespaceDescriptor;
-use log::warn;
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct FeatureComboDesc {
@@ -541,9 +540,10 @@ impl ModelInstance {
         }
 
         for (hyper_name, hyper_value) in replacement_hyperparam_ids.into_iter() {
-            warn!(
+            log::warn!(
                 "Warning! Updated hyperparameter {} to value {}",
-                hyper_name, hyper_value
+                hyper_name,
+                hyper_value
             );
         }
 

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,4 +1,3 @@
-use log::info;
 use std::marker::PhantomData;
 
 pub trait OptimizerTrait: std::clone::Clone {
@@ -120,7 +119,7 @@ impl OptimizerTrait for OptimizerAdagradLUT {
     }
 
     fn init(&mut self, learning_rate: f32, power_t: f32, initial_acc_gradient: f32) {
-        info!("Calculating look-up tables for Adagrad learning rate calculation");
+        log::info!("Calculating look-up tables for Adagrad learning rate calculation");
         let minus_power_t = -power_t;
         for x in 0..FASTMATH_LR_LUT_SIZE {
             // accumulated gradients are always positive floating points, sign is guaranteed to be zero

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,5 +1,5 @@
+use log::info;
 use std::marker::PhantomData;
-use log::{info};
 
 pub trait OptimizerTrait: std::clone::Clone {
     type PerWeightStore: std::clone::Clone;

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,4 +1,5 @@
 use std::marker::PhantomData;
+use log::{info};
 
 pub trait OptimizerTrait: std::clone::Clone {
     type PerWeightStore: std::clone::Clone;
@@ -119,7 +120,7 @@ impl OptimizerTrait for OptimizerAdagradLUT {
     }
 
     fn init(&mut self, learning_rate: f32, power_t: f32, initial_acc_gradient: f32) {
-        println!("Calculating look-up tables for Adagrad learning rate calculation");
+        info!("Calculating look-up tables for Adagrad learning rate calculation");
         let minus_power_t = -power_t;
         for x in 0..FASTMATH_LR_LUT_SIZE {
             // accumulated gradients are always positive floating points, sign is guaranteed to be zero
@@ -260,8 +261,7 @@ mod tests {
                     } else {
                         relative_error = error; // happens when the update is 0.0
                     }
-                    //println!("Relative error {}", relative_error);
-                    //println!("Err: {} - p_flex: {}, p_lut: {}, gradient: {}, accumulation {}", error, p_flex, p_lut, *gradient, *accumulation);
+
                     assert!(relative_error < 0.05);
                 }
             }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,6 +1,5 @@
 use crate::vwmap;
 use fasthash::murmur3;
-use log::{info, warn};
 use std::error::Error;
 use std::fmt;
 use std::io::BufRead;
@@ -93,7 +92,7 @@ impl VowpalParser {
     }
 
     pub fn print(&self) -> () {
-        info!("item out {:?}", self.output_buffer);
+        log::info!("item out {:?}", self.output_buffer);
     }
 
     #[inline(always)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,6 @@
 use crate::vwmap;
 use fasthash::murmur3;
+use log::{info, warn};
 use std::error::Error;
 use std::fmt;
 use std::io::BufRead;
@@ -7,7 +8,6 @@ use std::io::Error as IOError;
 use std::io::ErrorKind;
 use std::str;
 use std::string::String;
-use log::{info, warn};
 
 const RECBUF_LEN: usize = 2048;
 pub const HEADER_LEN: u32 = 3;
@@ -104,7 +104,6 @@ impl VowpalParser {
         error_str: &str,
     ) -> Result<f32, Box<dyn Error>> {
         unsafe {
-
             if i_end - i_start == 4
                 && self.tmp_read_buf[i_start + 0] == 'N' as u8
                 && self.tmp_read_buf[i_start + 1] == 'O' as u8

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,7 @@ use std::io::Error as IOError;
 use std::io::ErrorKind;
 use std::str;
 use std::string::String;
+use log::{info, warn};
 
 const RECBUF_LEN: usize = 2048;
 pub const HEADER_LEN: u32 = 3;
@@ -92,7 +93,7 @@ impl VowpalParser {
     }
 
     pub fn print(&self) -> () {
-        println!("item out {:?}", self.output_buffer);
+        info!("item out {:?}", self.output_buffer);
     }
 
     #[inline(always)]
@@ -103,7 +104,7 @@ impl VowpalParser {
         error_str: &str,
     ) -> Result<f32, Box<dyn Error>> {
         unsafe {
-            //            println!("{}", str::from_utf8_unchecked(&self.tmp_read_buf[i_start..i_end]));
+
             if i_end - i_start == 4
                 && self.tmp_read_buf[i_start + 0] == 'N' as u8
                 && self.tmp_read_buf[i_start + 1] == 'O' as u8
@@ -276,7 +277,6 @@ impl VowpalParser {
                     i_end += 1;
                 }
 
-                //println!("item out {:?}", std::str::from_utf8(&rr.tmp_read_buf[i_start..i_end]));
                 if *p.add(i_start) == 0x7c {
                     // "|"
                     // new namespace index
@@ -291,9 +291,9 @@ impl VowpalParser {
                     } else {
                         current_namespace_weight = 1.0;
                     }
-                    //   print!("Only single letter namespaces are allowed, however namespace string is: {:?}\n", String::from_utf8_lossy(&self.tmp_read_buf[i_start..i_end_first_part]));
+
                     let current_vwname = &self.tmp_read_buf[i_start..i_end_first_part];
-                    //                        println!("Current: {:?}", current_vwname);
+
                     let current_namespace_descriptor = match self
                         .vw_map
                         .map_vwname_to_namespace_descriptor

--- a/src/serving.rs
+++ b/src/serving.rs
@@ -17,7 +17,6 @@ use crate::persistence;
 use crate::port_buffer;
 use crate::regressor;
 use crate::vwmap;
-use log::info;
 
 pub struct Serving {
     listening_interface: String,
@@ -196,7 +195,7 @@ impl Serving {
         let receiver = Arc::new(Mutex::new(receiver));
 
         let listening_interface = format!("127.0.0.1:{}", port);
-        info!("Starting to listen on {}", listening_interface);
+        log::info!("Starting to listen on {}", listening_interface);
         let mut s = Serving {
             listening_interface: listening_interface.to_string(),
             worker_threads: Vec::new(),
@@ -210,7 +209,7 @@ impl Serving {
                 .expect("num_children should be integer"),
             None => 10,
         };
-        info!("Number of threads {}", num_children);
+        log::info!("Number of threads {}", num_children);
 
         if !s.foreground {
             //  let stdout = File::create("/tmp/daemon.out").unwrap();
@@ -245,7 +244,7 @@ impl Serving {
     pub fn serve(&mut self) -> Result<(), Box<dyn Error>> {
         let listener = net::TcpListener::bind(&self.listening_interface)
             .expect("Cannot bind to the interface");
-        info!("Bind done, deamonizing and calling accept");
+        log::info!("Bind done, deamonizing and calling accept");
         for stream in listener.incoming() {
             self.sender.send(stream?)?;
         }

--- a/src/serving.rs
+++ b/src/serving.rs
@@ -17,6 +17,7 @@ use crate::persistence;
 use crate::port_buffer;
 use crate::regressor;
 use crate::vwmap;
+use log::{info};
 
 pub struct Serving {
     listening_interface: String,
@@ -94,7 +95,6 @@ impl WorkerThread {
                     match writer.write_all(p_res.as_bytes()) {
                         Ok(_) => {}
                         Err(_e) => {
-                            /*println!("Write to socket failed, dropping it"); */
                             return ConnectionEnd::StreamWriteError;
                         }
                     };
@@ -122,7 +122,6 @@ impl WorkerThread {
                                 match writer.write_all(p_res.as_bytes()) {
                                     Ok(_) => {}
                                     Err(_e) => {
-                                        /*println!("Write to socket failed, dropping it"); */
                                         return ConnectionEnd::StreamWriteError;
                                     }
                                 };
@@ -133,7 +132,6 @@ impl WorkerThread {
                                 match writer.write_all(p_res.as_bytes()) {
                                     Ok(_) => {}
                                     Err(_e) => {
-                                        /*println!("Write to socket failed, dropping it"); */
                                         return ConnectionEnd::StreamWriteError;
                                     }
                                 };
@@ -146,12 +144,10 @@ impl WorkerThread {
                             Ok(_) => match writer.flush() {
                                 Ok(_) => {}
                                 Err(_e) => {
-                                    /*println!("Flushing the socket failed, dropping it");*/
                                     return ConnectionEnd::StreamFlushError;
                                 }
                             },
                             Err(_e) => {
-                                /*println!("Write to socket failed, dropping it"); */
                                 return ConnectionEnd::StreamWriteError;
                             }
                         };
@@ -165,7 +161,6 @@ impl WorkerThread {
                 match writer.flush() {
                     Ok(_) => {}
                     Err(_e) => {
-                        /*println!("Flushing the socket failed, dropping it");*/
                         return ConnectionEnd::StreamFlushError;
                     }
                 };
@@ -201,7 +196,7 @@ impl Serving {
         let receiver = Arc::new(Mutex::new(receiver));
 
         let listening_interface = format!("127.0.0.1:{}", port);
-        println!("Starting to listen on {}", listening_interface);
+        info!("Starting to listen on {}", listening_interface);
         let mut s = Serving {
             listening_interface: listening_interface.to_string(),
             worker_threads: Vec::new(),
@@ -215,7 +210,7 @@ impl Serving {
                 .expect("num_children should be integer"),
             None => 10,
         };
-        println!("Number of threads {}", num_children);
+        info!("Number of threads {}", num_children);
 
         if !s.foreground {
             //  let stdout = File::create("/tmp/daemon.out").unwrap();
@@ -250,7 +245,7 @@ impl Serving {
     pub fn serve(&mut self) -> Result<(), Box<dyn Error>> {
         let listener = net::TcpListener::bind(&self.listening_interface)
             .expect("Cannot bind to the interface");
-        println!("Bind done, deamonizing and calling accept");
+        info!("Bind done, deamonizing and calling accept");
         for stream in listener.incoming() {
             self.sender.send(stream?)?;
         }
@@ -360,7 +355,6 @@ C,featureC
                 newt.handle_connection(&mut reader, &mut writer)
             );
         }
-        //    println!("Return value {:?}", std::str::from_utf8(&x).unwrap());
     }
 
     fn lr_and_ffm_vec(

--- a/src/serving.rs
+++ b/src/serving.rs
@@ -17,7 +17,7 @@ use crate::persistence;
 use crate::port_buffer;
 use crate::regressor;
 use crate::vwmap;
-use log::{info};
+use log::info;
 
 pub struct Serving {
     listening_interface: String,

--- a/src/vwmap.rs
+++ b/src/vwmap.rs
@@ -1,3 +1,4 @@
+use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
@@ -6,7 +7,6 @@ use std::io::prelude::*;
 use std::io::Error as IOError;
 use std::io::ErrorKind;
 use std::path::PathBuf;
-use log::{info, warn};
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Eq)]
 pub enum NamespaceType {

--- a/src/vwmap.rs
+++ b/src/vwmap.rs
@@ -6,6 +6,7 @@ use std::io::prelude::*;
 use std::io::Error as IOError;
 use std::io::ErrorKind;
 use std::path::PathBuf;
+use log::{info, warn};
 
 #[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize, Eq)]
 pub enum NamespaceType {
@@ -114,14 +115,14 @@ impl VwNamespaceMap {
             let record = record_w?;
             let vwname_str = &record[0];
             if vwname_str.as_bytes().len() != 1 && i == 0 {
-                println!("Warning: multi-byte namespace names are not compatible with old style namespace arguments");
+                warn!("Warning: multi-byte namespace names are not compatible with old style namespace arguments");
             }
 
             if vwname_str == "_namespace_skip_prefix" {
                 let namespace_skip_prefix = record[1]
                     .parse()
                     .expect("Couldn't parse _namespace_skip_prefix in vw_namespaces_map.csv");
-                println!(
+                info!(
                     "_namespace_skip_prefix set in vw_namespace_map.csv is {}",
                     namespace_skip_prefix
                 );

--- a/src/vwmap.rs
+++ b/src/vwmap.rs
@@ -1,4 +1,3 @@
-use log::{info, warn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;
@@ -115,14 +114,14 @@ impl VwNamespaceMap {
             let record = record_w?;
             let vwname_str = &record[0];
             if vwname_str.as_bytes().len() != 1 && i == 0 {
-                warn!("Warning: multi-byte namespace names are not compatible with old style namespace arguments");
+                log::warn!("Warning: multi-byte namespace names are not compatible with old style namespace arguments");
             }
 
             if vwname_str == "_namespace_skip_prefix" {
                 let namespace_skip_prefix = record[1]
                     .parse()
                     .expect("Couldn't parse _namespace_skip_prefix in vw_namespaces_map.csv");
-                info!(
+                log::info!(
                     "_namespace_skip_prefix set in vw_namespace_map.csv is {}",
                     namespace_skip_prefix
                 );


### PR DESCRIPTION
A suggestion for a minimal logging interface (operational) + some cleanup of commented out/unused source.
Logger is initialized at the start of `main()` with all types printed out - no need for environment variables.