### PR TITLE
Up to 2.4x faster training (for deep models)

### DIFF
--- a/src/block_neural.rs
+++ b/src/block_neural.rs
@@ -462,7 +462,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockNeuronLayer<L> {
         pb: &mut port_buffer::PortBuffer,
     ) {
         unsafe {
-            let frandseed = fb.example_number * fb.example_number;
+
             let bias_offset = self.num_inputs * self.num_neurons;
             let (input_tape, output_tape) = block_helpers::get_input_output_borrows(
                 &mut pb.tape,

--- a/src/block_neural.rs
+++ b/src/block_neural.rs
@@ -385,6 +385,11 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockNeuronLayer<L> {
 
                         let general_gradient = output_tape.get_unchecked(j) * self.dropout_inv;
 
+			// if this is zero, subsequent multiplications make no sense
+			if general_gradient == 0.0 {
+			    continue;
+			}
+
                         let j_offset = j * self.num_inputs as usize;
                         for i in 0..self.num_inputs as usize {
                             let feature_value = input_tape.get_unchecked(i);


### PR DESCRIPTION
Turns out individual neuron updates (part after sgemv) are quite computationally heavy. While profiling, identified a corner case where quite a few operations are completely redundant -- scenario where general gradient is zero. This turns out to be surprisingly common (based on statistics of grad dumps), lending itself as an interesting optimization opportunity. 

By skipping updates where everything would be zeroed-out anyways, this offers consistent 1.43x speedup with no loss in predictive performance for a regular 2-h-layer architecture 75-150.

In theory this effect should be even more apparent for deeper nets, which turned out to be the case. For a 150-300 network, the speedup is 2.4x.

Just to test the scaling law here a bit more, also ran unrealistic 300-600 net. The speedup here was 4.1x.

