### PR TITLE
FeatureBuffer ffm_fields_count removed as it is already present in BlockFFM as ffm_num_fields

### DIFF
--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -141,7 +141,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
                     let ffmk: u32 = self.ffm_k;
                     let ffmk_as_usize: usize = ffmk as usize;
 
-                    let ffm_fields_count: u32 = fb.ffm_fields_count;
+                    let ffm_fields_count: u32 = self.ffm_num_fields;
                     let ffm_fields_count_as_usize: usize = ffm_fields_count as usize;
 
                     let fc: usize = ffm_fields_count_as_usize * ffmk_as_usize;
@@ -264,7 +264,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
 
                         for feature in &fb.ffm_buffer {
                             let mut feature_index = feature.hash as usize;
-                            let contra_offset = (feature.contra_field_index * fb.ffm_fields_count) as usize / ffmk_as_usize;
+                            let contra_offset = (feature.contra_field_index * ffm_fields_count) as usize / ffmk_as_usize;
 
                             for z in 0..ffm_fields_count_as_usize {
                                 let general_gradient = myslice.get_unchecked(contra_offset + z);
@@ -287,7 +287,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
                 }
             } // End of macro
 
-            let local_data_ffm_len = fb.ffm_buffer.len() * (self.ffm_k * fb.ffm_fields_count) as usize;
+            let local_data_ffm_len = fb.ffm_buffer.len() * (self.ffm_k * self.ffm_num_fields) as usize;
             if local_data_ffm_len < FFM_STACK_BUF_LEN {
                 // Fast-path - using on-stack data structures
                 let mut local_data_ffm_values: [f32; FFM_STACK_BUF_LEN as usize] =
@@ -341,7 +341,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
             let ffmk: u32 = self.ffm_k;
             let ffmk_as_usize: usize = ffmk as usize;
 
-            let ffm_fields_count: u32 = fb.ffm_fields_count;
+            let ffm_fields_count: u32 = self.ffm_num_fields;
             let ffm_fields_count_as_usize: usize = ffm_fields_count as usize;
             let ffm_fields_count_plus_one = ffm_fields_count + 1;
 
@@ -527,7 +527,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
             let ffmk: u32 = self.ffm_k;
             let ffmk_as_usize: usize = ffmk as usize;
 
-            let ffm_fields_count: u32 = fb.ffm_fields_count;
+            let ffm_fields_count: u32 = self.ffm_num_fields;
             let ffm_fields_count_as_usize: usize = ffm_fields_count as usize;
             let ffm_fields_count_plus_one = ffm_fields_count + 1;
 
@@ -733,7 +733,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
             let ffmk: u32 = self.ffm_k;
             let ffmk_as_usize: usize = ffmk as usize;
 
-            let ffm_fields_count: u32 = fb.ffm_fields_count;
+            let ffm_fields_count: u32 = self.ffm_num_fields;
             let ffm_fields_count_as_usize: usize = ffm_fields_count as usize;
             let ffm_fields_count_plus_one = ffm_fields_count + 1;
 
@@ -971,7 +971,6 @@ mod tests {
             example_number: 0,
             lr_buffer: Vec::new(),
             ffm_buffer: v,
-            ffm_fields_count,
         }
     }
 

--- a/src/block_misc.rs
+++ b/src/block_misc.rs
@@ -955,7 +955,6 @@ mod tests {
             example_number: 0,
             lr_buffer: Vec::new(),
             ffm_buffer: Vec::new(),
-            ffm_fields_count: 0,
         }
     }
 

--- a/src/block_neural.rs
+++ b/src/block_neural.rs
@@ -523,7 +523,6 @@ mod tests {
             example_number: 0,
             lr_buffer: Vec::new(),
             ffm_buffer: Vec::new(),
-            ffm_fields_count: 0,
         }
     }
 

--- a/src/block_normalize.rs
+++ b/src/block_normalize.rs
@@ -301,7 +301,6 @@ mod tests {
                     example_number: 0,
                     lr_buffer: Vec::new(),
                     ffm_buffer: Vec::new(),
-                    ffm_fields_count: 0,
         }
     }
 

--- a/src/block_relu.rs
+++ b/src/block_relu.rs
@@ -160,7 +160,6 @@ mod tests {
             example_number: 0,
             lr_buffer: Vec::new(),
             ffm_buffer: Vec::new(),
-            ffm_fields_count: 0,
         }
     }
 

--- a/src/feature_buffer.rs
+++ b/src/feature_buffer.rs
@@ -28,7 +28,6 @@ pub struct FeatureBuffer {
     pub example_number: u64,
     pub lr_buffer: Vec<HashAndValue>,
     pub ffm_buffer: Vec<HashAndValueAndSeq>,
-    pub ffm_fields_count: u32,
 }
 
 #[derive(Clone)]
@@ -154,7 +153,6 @@ impl FeatureBufferTranslator {
             example_number: 0,
             lr_buffer: Vec::new(),
             ffm_buffer: Vec::new(),
-            ffm_fields_count: 0,
         };
 
         // avoid doing any allocations in translate
@@ -275,8 +273,7 @@ impl FeatureBufferTranslator {
                 // but in theory we could support also combo features
                 let ffm_buffer = &mut self.feature_buffer.ffm_buffer;
                 ffm_buffer.truncate(0);
-                self.feature_buffer.ffm_fields_count = self.model_instance.ffm_fields.len() as u32;
-                //let feature_len = self.feature_buffer.ffm_fields_count * self.model_instance.ffm_k;
+
                 for (contra_field_index, ffm_field) in
                     self.model_instance.ffm_fields.iter().enumerate()
                 {

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -222,7 +222,6 @@ B,featureB
             example_number: 0,
             lr_buffer: v,
             ffm_buffer: Vec::new(),
-            ffm_fields_count: 0,
         }
     }
 
@@ -308,7 +307,6 @@ B,featureB
 
     fn ffm_vec(
         v: Vec<feature_buffer::HashAndValueAndSeq>,
-        ffm_fields_count: u32,
     ) -> feature_buffer::FeatureBuffer {
         feature_buffer::FeatureBuffer {
             label: 0.0,
@@ -316,7 +314,6 @@ B,featureB
             example_number: 0,
             lr_buffer: Vec::new(),
             ffm_buffer: v,
-            ffm_fields_count,
         }
     }
 
@@ -361,7 +358,6 @@ B,featureB
                     contra_field_index: 1,
                 },
             ],
-            2,
         );
         pb.reset();
         p = re.learn(fbuf, &mut pb, true);
@@ -407,7 +403,6 @@ B,featureB
     fn lr_and_ffm_vec(
         v1: Vec<feature_buffer::HashAndValue>,
         v2: Vec<feature_buffer::HashAndValueAndSeq>,
-        ffm_fields_count: u32,
     ) -> feature_buffer::FeatureBuffer {
         feature_buffer::FeatureBuffer {
             label: 0.0,
@@ -415,7 +410,6 @@ B,featureB
             example_number: 0,
             lr_buffer: v1,
             ffm_buffer: v2,
-            ffm_fields_count,
         }
     }
 
@@ -476,7 +470,6 @@ B,featureB
                     contra_field_index: 1,
                 },
             ],
-            2,
         );
         let fbuf_2 = &lr_and_ffm_vec(
             vec![
@@ -508,7 +501,6 @@ B,featureB
                     contra_field_index: 1,
                 },
             ],
-            2,
         );
 
         p = re_1.learn(fbuf_1, &mut pb_1, true);

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -538,7 +538,6 @@ mod tests {
             example_number: 0,
             lr_buffer: v,
             ffm_buffer: Vec::new(),
-            ffm_fields_count: 0,
         }
     }
 

--- a/src/serving.rs
+++ b/src/serving.rs
@@ -356,21 +356,6 @@ C,featureC
         }
     }
 
-    fn lr_and_ffm_vec(
-        v1: Vec<feature_buffer::HashAndValue>,
-        v2: Vec<feature_buffer::HashAndValueAndSeq>,
-        ffm_fields_count: u32,
-    ) -> feature_buffer::FeatureBuffer {
-        feature_buffer::FeatureBuffer {
-            label: 0.0,
-            example_importance: 1.0,
-            example_number: 0,
-            lr_buffer: v1,
-            ffm_buffer: v2,
-            ffm_fields_count,
-        }
-    }
-
     #[test]
     fn test_hogwild() {
         let vw_map_string = r#"


### PR DESCRIPTION
FeatureBuffer `ffm_fields_count` has been removed as it is already present in BlockFFM as the `ffm_num_fields` field.
