### PR TITLE
Parsing of empty strings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,9 @@ use std::io::Cursor;
 use std::os::raw::c_char;
 use crate::regressor::BlockCache;
 
+const EOF_ERROR_CODE: f32 = -1.0;
+const EXCEPTION_ERROR_CODE: f32 = -1.0;
+
 #[repr(C)]
 pub struct FfiPredictor {
     _marker: core::marker::PhantomData<Predictor>,
@@ -63,9 +66,15 @@ impl Predictor {
         let mut buffered_input = Cursor::new(input_buffer);
         let reading_result = self.vw_parser.next_vowpal(&mut buffered_input);
         let buffer = match reading_result {
-            Ok([]) => return -1.0, // EOF
+            Ok([]) => {
+                log::error!("Reading result for prediction returns EOF");
+                return EOF_ERROR_CODE
+            }, // EOF
             Ok(buffer2) => buffer2,
-            Err(_e) => return -1.0,
+            Err(e) => {
+                log::error!("Reading result for prediction returns error {}", e);
+                return EXCEPTION_ERROR_CODE
+            }
         };
         self.feature_buffer_translator.translate(buffer, 0);
         self.regressor
@@ -78,9 +87,15 @@ impl Predictor {
             .next_vowpal_with_cache(&mut buffered_input, self.cache.input_buffer_size);
 
         let buffer = match reading_result {
-            Ok([]) => return -1.0, // EOF
+            Ok([]) => {
+                log::error!("Reading result for prediction with cache returns EOF");
+                return EOF_ERROR_CODE
+            }, // EOF
             Ok(buffer2) => buffer2,
-            Err(_e) => return -1.0,
+            Err(e) => {
+                log::error!("Reading result for prediction with cache returns error {}", e);
+                return EXCEPTION_ERROR_CODE
+            }
         };
 
         self.feature_buffer_translator.translate(buffer, 0);
@@ -91,9 +106,15 @@ impl Predictor {
         let mut buffered_input = Cursor::new(input_buffer);
         let reading_result = self.vw_parser.next_vowpal_with_size(&mut buffered_input);
         let (buffer, input_buffer_size) = match reading_result {
-            Ok(([], _)) => return -1.0, // EOF
+            Ok(([], _)) => {
+                log::error!("Reading result for prediction with cache returns EOF");
+                return EOF_ERROR_CODE
+            }, // EOF
             Ok(buffer2) => buffer2,
-            Err(_e) => return -1.0,
+            Err(e) => {
+                log::error!("Reading result for prediction with cache returns error {}", e);
+                return EXCEPTION_ERROR_CODE
+            }
         };
         // ignore last newline byte
         self.cache.input_buffer_size = input_buffer_size;
@@ -188,7 +209,7 @@ pub unsafe extern "C" fn free_predictor(ptr: *mut FfiPredictor) {
 
 unsafe fn from_ptr<'a>(ptr: *mut FfiPredictor) -> &'a mut Predictor {
     if ptr.is_null() {
-	log::error!("Fatal error, got NULL `Context` pointer");
+	    log::error!("Fatal error, got NULL `Context` pointer");
         std::process::abort();
     }
     &mut *(ptr.cast())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -195,11 +195,14 @@ impl VowpalParser {
         self.tmp_read_buf.truncate(cached_tmp_read_buf_size);
 
         let tmp_read_buf_size = match input_bufread.read_until(0x0a, &mut self.tmp_read_buf) {
-            Ok(0) => return Ok(&[]),
-            Ok(n) => n,
+            Ok(n) => n + cached_tmp_read_buf_size,
             Err(e) => Err(e)?,
         };
-        return self.next_vowpal_to_size(cached_tmp_read_buf_size + tmp_read_buf_size);
+
+        if tmp_read_buf_size == 0 {
+            return Ok(&[]);
+        }
+        return self.next_vowpal_to_size(tmp_read_buf_size);
     }
 
     fn next_vowpal_to_size(
@@ -1101,6 +1104,92 @@ CC,featureC
         );
 
         let mut added_cache_buf = str_to_cursor("|AA:3 a:2.0 \n");
+
+        // feature weight + namespace weight
+        assert_eq!(
+            rr.next_vowpal_with_cache(&mut added_cache_buf, cache_result_size).unwrap(),
+            buf_result
+        );
+    }
+
+    #[test]
+    fn test_cache_with_fully_cached_request() {
+        // Test for perfect vowpal-compatible hashing
+        let vw_map_string = r#"
+AA,featureA
+BB,featureB
+CC,featureC
+"#;
+        let vw = vwmap::VwNamespaceMap::new(vw_map_string).unwrap();
+
+        fn str_to_cursor(s: &str) -> Cursor<Vec<u8>> {
+            Cursor::new(s.as_bytes().to_vec())
+        }
+
+        let mut rr = VowpalParser::new(&vw);
+
+        let mut buf = str_to_cursor("|BB b |AA:3 a:2.0 \n");
+        let buf_result =
+            [8, 255, 1065353216, 2147876872, 1123906636, 2147483648, 292540976, 1086324736];
+
+        assert_eq!(
+            rr.next_vowpal(&mut buf).unwrap(),
+            buf_result
+        );
+
+        let cache_input_str = "|BB b |AA:3 a:2.0 \n";
+        let mut cache_buf = str_to_cursor(cache_input_str);
+        let (cache_result, cache_result_size) = rr.next_vowpal_with_size(&mut cache_buf).unwrap();
+
+        assert_eq!(
+            cache_result,
+            buf_result
+        );
+
+        let mut added_cache_buf = str_to_cursor("");
+
+        // feature weight + namespace weight
+        assert_eq!(
+            rr.next_vowpal_with_cache(&mut added_cache_buf, cache_result_size).unwrap(),
+            buf_result
+        );
+    }
+
+    #[test]
+    fn test_cache_with_empty_cached_request() {
+        // Test for perfect vowpal-compatible hashing
+        let vw_map_string = r#"
+AA,featureA
+BB,featureB
+CC,featureC
+"#;
+        let vw = vwmap::VwNamespaceMap::new(vw_map_string).unwrap();
+
+        fn str_to_cursor(s: &str) -> Cursor<Vec<u8>> {
+            Cursor::new(s.as_bytes().to_vec())
+        }
+
+        let mut rr = VowpalParser::new(&vw);
+
+        let mut buf = str_to_cursor("|BB b |AA:3 a:2.0 \n");
+        let buf_result =
+            [8, 255, 1065353216, 2147876872, 1123906636, 2147483648, 292540976, 1086324736];
+
+        assert_eq!(
+            rr.next_vowpal(&mut buf).unwrap(),
+            buf_result
+        );
+
+        let cache_input_str = "";
+        let mut cache_buf = str_to_cursor(cache_input_str);
+        let (cache_result, cache_result_size) = rr.next_vowpal_with_size(&mut cache_buf).unwrap();
+
+        assert_eq!(
+            cache_result,
+            []
+        );
+
+        let mut added_cache_buf = str_to_cursor("|BB b |AA:3 a:2.0 \n");
 
         // feature weight + namespace weight
         assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1184,9 +1184,10 @@ CC,featureC
         let mut cache_buf = str_to_cursor(cache_input_str);
         let (cache_result, cache_result_size) = rr.next_vowpal_with_size(&mut cache_buf).unwrap();
 
+        let empty_result: &[u32] = &[];
         assert_eq!(
             cache_result,
-            []
+            empty_result
         );
 
         let mut added_cache_buf = str_to_cursor("|BB b |AA:3 a:2.0 \n");


### PR DESCRIPTION
When adding the cache functionality a case was missed where all values for parsing were passed as cached values and there are no non-cached values to be passed (an empty string is received).

This PR addresses this and adds additional logging that allows easier troubleshooting. 