### PR TITLE
Fix warnings

### DIFF
--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -968,13 +968,6 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
         )?;
         Ok(())
     }
-
-    /// Sets internal state of weights based on some completely object-dependent parameters
-    fn testing_set_weights(&mut self, index: usize, w: &[f32]) -> Result<(), Box<dyn Error>> {
-        self.weights[index] = w[0];
-        self.optimizer[index].optimizer_data = self.optimizer_ffm.initial_data();
-        Ok(())
-    }
 }
 
 mod tests {

--- a/src/block_helpers.rs
+++ b/src/block_helpers.rs
@@ -154,7 +154,7 @@ pub fn get_input_output_borrows(
     }
 }
 
-pub fn slearn2<'a>(
+pub fn slearn2(
     bg: &mut graph::BlockGraph,
     fb: &feature_buffer::FeatureBuffer,
     pb: &mut port_buffer::PortBuffer,
@@ -167,7 +167,7 @@ pub fn slearn2<'a>(
     pb.observations[0]
 }
 
-pub fn ssetup_cache2<'a>(
+pub fn ssetup_cache2(
     bg: &mut graph::BlockGraph,
     cache_fb: &feature_buffer::FeatureBuffer,
     caches: &mut Vec<BlockCache>,
@@ -183,7 +183,7 @@ pub fn ssetup_cache2<'a>(
     );
 }
 
-pub fn spredict2_with_cache<'a>(
+pub fn spredict2_with_cache(
     bg: &mut graph::BlockGraph,
     fb: &feature_buffer::FeatureBuffer,
     pb: &mut port_buffer::PortBuffer,
@@ -196,7 +196,7 @@ pub fn spredict2_with_cache<'a>(
     pb.observations[0]
 }
 
-pub fn spredict2<'a>(
+pub fn spredict2(
     bg: &mut graph::BlockGraph,
     fb: &feature_buffer::FeatureBuffer,
     pb: &mut port_buffer::PortBuffer,

--- a/src/block_loss_functions.rs
+++ b/src/block_loss_functions.rs
@@ -118,7 +118,6 @@ impl BlockTrait for BlockSigmoid {
                 .get_unchecked(self.input_offset..(self.input_offset + self.num_inputs))
                 .iter()
                 .sum();
-            // vowpal compatibility
 
             let prediction_probability: f32;
             let general_gradient: f32;

--- a/src/block_loss_functions.rs
+++ b/src/block_loss_functions.rs
@@ -50,12 +50,11 @@ impl BlockSigmoid {
         unsafe {
             debug_assert!(self.input_offset != usize::MAX);
             debug_assert!(self.output_offset != usize::MAX);
-            let wsum: f32 = {
-                let myslice = pb
-                    .tape
-                    .get_unchecked(self.input_offset..(self.input_offset + self.num_inputs));
-                myslice.iter().sum()
-            };
+            let wsum: f32 = pb
+                .tape
+                .get_unchecked(self.input_offset..(self.input_offset + self.num_inputs))
+                .iter()
+                .sum();
 
             let prediction_probability: f32;
             if wsum.is_nan() {
@@ -114,16 +113,15 @@ impl BlockTrait for BlockSigmoid {
         debug_assert!(self.output_offset != usize::MAX);
 
         unsafe {
-            let wsum: f32 = {
-                let myslice = &pb
-                    .tape
-                    .get_unchecked(self.input_offset..(self.input_offset + self.num_inputs));
-                myslice.iter().sum()
-            };
+            let wsum: f32 = pb
+                .tape
+                .get_unchecked(self.input_offset..(self.input_offset + self.num_inputs))
+                .iter()
+                .sum();
             // vowpal compatibility
 
-            let mut prediction_probability: f32;
-            let mut general_gradient: f32;
+            let prediction_probability: f32;
+            let general_gradient: f32;
 
             if wsum.is_nan() {
                 log::error!(

--- a/src/block_lr.rs
+++ b/src/block_lr.rs
@@ -289,11 +289,4 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockLR<L> {
             input_bufreader,
         )
     }
-
-    /// Sets internal state of weights based on some completely object-dependent parameters
-    fn testing_set_weights(&mut self, index: usize, w: &[f32]) -> Result<(), Box<dyn Error>> {
-        self.weights[index].weight = w[0];
-        self.weights[index].optimizer_data = self.optimizer_lr.initial_data();
-        Ok(())
-    }
 }

--- a/src/block_lr.rs
+++ b/src/block_lr.rs
@@ -32,18 +32,16 @@ impl<L: OptimizerTrait + 'static> BlockLR<L> {
     ) {
         debug_assert!(self.output_offset != usize::MAX);
 
-        {
-            unsafe {
-                let myslice = &mut pb.tape
-                    [self.output_offset..(self.output_offset + self.num_combos as usize)];
-                myslice.fill(0.0);
-                for feature in fb.lr_buffer.iter() {
-                    let feature_index = feature.hash as usize;
-                    let feature_value = feature.value;
-                    let combo_index = feature.combo_index as usize;
-                    *myslice.get_unchecked_mut(combo_index) +=
-                        self.weights.get_unchecked(feature_index).weight * feature_value;
-                }
+        unsafe {
+            let myslice =
+                &mut pb.tape[self.output_offset..(self.output_offset + self.num_combos as usize)];
+            myslice.fill(0.0);
+            for feature in fb.lr_buffer.iter() {
+                let feature_index = feature.hash as usize;
+                let feature_value = feature.value;
+                let combo_index = feature.combo_index as usize;
+                *myslice.get_unchecked_mut(combo_index) +=
+                    self.weights.get_unchecked(feature_index).weight * feature_value;
             }
         }
     }
@@ -96,7 +94,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockLR<L> {
         self
     }
 
-    fn allocate_and_init_weights(&mut self, mi: &model_instance::ModelInstance) {
+    fn allocate_and_init_weights(&mut self, _mi: &model_instance::ModelInstance) {
         self.weights = vec![
             WeightAndOptimizerData::<L> {
                 weight: 0.0,
@@ -187,7 +185,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockLR<L> {
         };
 
         unsafe {
-            let mut lr_slice =
+            let lr_slice =
                 &mut pb.tape[self.output_offset..(self.output_offset + self.num_combos as usize)];
             lr_slice.copy_from_slice(lr.as_slice());
 
@@ -240,7 +238,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockLR<L> {
             combo_indexes.fill(false);
             lr.fill(0.0);
 
-            let mut lr_slice = lr.as_mut_slice();
+            let lr_slice = lr.as_mut_slice();
 
             for feature in fb.lr_buffer.iter() {
                 if (feature.hash & parser::IS_NOT_SINGLE_MASK) == 0 {
@@ -293,13 +291,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockLR<L> {
     }
 
     /// Sets internal state of weights based on some completely object-dependent parameters
-    fn testing_set_weights(
-        &mut self,
-        _aa: i32,
-        _bb: i32,
-        index: usize,
-        w: &[f32],
-    ) -> Result<(), Box<dyn Error>> {
+    fn testing_set_weights(&mut self, index: usize, w: &[f32]) -> Result<(), Box<dyn Error>> {
         self.weights[index].weight = w[0];
         self.weights[index].optimizer_data = self.optimizer_lr.initial_data();
         Ok(())

--- a/src/block_misc.rs
+++ b/src/block_misc.rs
@@ -1005,7 +1005,7 @@ mod tests {
                 2.0, 3.0, // 2nd copy of forward
                 11.0, 11.0,
             ]
-        ); // backward part  (6+11)
+        );
 
         spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(
@@ -1051,7 +1051,7 @@ mod tests {
                 2.0, 3.0, // 2nd copy of forward
                 2.0, 3.0, 18.0, 18.0,
             ]
-        ); // backward part  (5+6+7)
+        );
 
         spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(
@@ -1150,12 +1150,13 @@ mod tests {
 
         let mut pb = bg.new_port_buffer();
         let fb = fb_vec();
+
+        // Order depends on the input parameters order, not on order of adding to graph ( join actually doesn't do anything)
         slearn2(&mut bg, &fb, &mut pb, true);
-        // Order depends on the input parameters order, not on order of adding to graph
-        assert_eq!(pb.observations, vec![6.0, 7.0, 1.0, 2.0, 3.0, 4.0, 5.0]); // join actually doesn't do anything
+        assert_eq!(pb.observations, vec![6.0, 7.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
 
         spredict2(&mut bg, &fb, &mut pb);
-        assert_eq!(pb.observations, vec![6.0, 7.0, 1.0, 2.0, 3.0, 4.0, 5.0]); // join actually doesn't do anything
+        assert_eq!(pb.observations, vec![6.0, 7.0, 1.0, 2.0, 3.0, 4.0, 5.0]);
     }
 
     #[test]

--- a/src/block_misc.rs
+++ b/src/block_misc.rs
@@ -197,7 +197,7 @@ pub fn new_sink_block(
         num_inputs,
         sink_type,
     });
-    let mut block_outputs = bg.add_node(block, vec![input])?;
+    let block_outputs = bg.add_node(block, vec![input])?;
     assert_eq!(block_outputs.len(), 0);
     Ok(())
 }
@@ -217,7 +217,7 @@ impl BlockTrait for BlockSink {
         0
     } // It is a pass-through
 
-    fn get_num_output_values(&self, output: graph::OutputSlot) -> usize {
+    fn get_num_output_values(&self, _output: graph::OutputSlot) -> usize {
         assert!(false, "No output values in BlockSink");
         0
     }
@@ -228,7 +228,7 @@ impl BlockTrait for BlockSink {
         self.input_offset = offset;
     }
 
-    fn set_output_offset(&mut self, output: graph::OutputSlot, offset: usize) {
+    fn set_output_offset(&mut self, _output: graph::OutputSlot, _offset: usize) {
         assert!(false, "No outputs in BlockSink");
     }
 
@@ -313,7 +313,7 @@ impl BlockTrait for BlockConsts {
         self.consts.len()
     }
 
-    fn set_input_offset(&mut self, input: graph::InputSlot, offset: usize) {
+    fn set_input_offset(&mut self, _input: graph::InputSlot, _offset: usize) {
         panic!("You cannot set input_tape_index for BlockConsts");
     }
 
@@ -374,7 +374,7 @@ pub fn new_copy_block(
     let num_inputs = bg.get_num_output_values(vec![&input]);
     assert_ne!(num_inputs, 0);
 
-    let mut block = Box::new(BlockCopy {
+    let block = Box::new(BlockCopy {
         output_offsets: vec![usize::MAX; num_output_slots],
         input_offset: usize::MAX,
         num_inputs,
@@ -541,7 +541,7 @@ pub fn new_join_block(
     let num_inputs = bg.get_num_output_values(inputs.iter().collect());
     assert_ne!(num_inputs, 0);
 
-    let mut block = Box::new(BlockJoin {
+    let block = Box::new(BlockJoin {
         output_offset: usize::MAX,
         input_offset: usize::MAX,
         num_inputs,
@@ -642,7 +642,7 @@ pub struct BlockSum {
 
 fn new_sum_without_weights(num_inputs: usize) -> Result<Box<dyn BlockTrait>, Box<dyn Error>> {
     assert!(num_inputs > 0);
-    let mut rg = BlockSum {
+    let rg = BlockSum {
         output_offset: usize::MAX,
         input_offset: usize::MAX,
         num_inputs,
@@ -769,7 +769,7 @@ pub fn new_triangle_block(
     }
     let square_width = num_inputs_sqrt;
     let num_outputs = square_width * (square_width + 1) / 2;
-    let mut block = Box::new(BlockTriangle {
+    let block = Box::new(BlockTriangle {
         output_offset: usize::MAX,
         input_offset: usize::MAX,
         num_inputs: square_width * square_width,
@@ -914,13 +914,13 @@ mod tests {
 
     #[test]
     fn test_sum_block() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block = block_misc::new_const_block(&mut bg, vec![2.0, 3.0]).unwrap();
         let observe_block_backward =
             block_misc::new_observe_block(&mut bg, input_block, Observe::Backward, None).unwrap();
         let sum_block = new_sum_block(&mut bg, observe_block_backward).unwrap();
-        let observe_block_forward =
+        let _observe_block_forward =
             block_misc::new_observe_block(&mut bg, sum_block, Observe::Forward, Some(1.0)).unwrap();
         bg.finalize();
         bg.allocate_and_init_weights(&mi);
@@ -936,7 +936,7 @@ mod tests {
             ]
         ); // backward part -- 1 is distributed to both inputs
 
-        spredict2(&mut bg, &fb, &mut pb, true);
+        spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(
             pb.observations,
             vec![
@@ -948,7 +948,7 @@ mod tests {
 
     #[test]
     fn test_triangle_block() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block = block_misc::new_const_block(&mut bg, vec![2.0, 4.0, 4.0, 5.0]).unwrap();
         let observe_block_backward =
@@ -979,17 +979,17 @@ mod tests {
 
     #[test]
     fn test_copy_block() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block = block_misc::new_const_block(&mut bg, vec![2.0, 3.0]).unwrap();
         let observe_block_backward =
             block_misc::new_observe_block(&mut bg, input_block, Observe::Backward, None).unwrap();
         let (copy_block_1, copy_block_2) =
             new_copy_block_2(&mut bg, observe_block_backward).unwrap();
-        let observe_block_1_forward =
+        let _observe_block_1_forward =
             block_misc::new_observe_block(&mut bg, copy_block_1, Observe::Forward, Some(5.0))
                 .unwrap();
-        let observe_block_2_forward =
+        let _observe_block_2_forward =
             block_misc::new_observe_block(&mut bg, copy_block_2, Observe::Forward, Some(6.0))
                 .unwrap();
         bg.finalize();
@@ -1007,7 +1007,7 @@ mod tests {
             ]
         ); // backward part  (6+11)
 
-        spredict2(&mut bg, &fb, &mut pb, false);
+        spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(
             pb.observations,
             vec![
@@ -1020,7 +1020,7 @@ mod tests {
 
     #[test]
     fn test_copy_block_cascade() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block = block_misc::new_const_block(&mut bg, vec![2.0, 3.0]).unwrap();
         let observe_block_backward =
@@ -1029,13 +1029,13 @@ mod tests {
             new_copy_block_2(&mut bg, observe_block_backward).unwrap();
         let (copy_block_3, copy_block_4) = new_copy_block_2(&mut bg, copy_block_1).unwrap();
 
-        let observe_block_1_forward =
+        let _observe_block_1_forward =
             block_misc::new_observe_block(&mut bg, copy_block_2, Observe::Forward, Some(5.0))
                 .unwrap();
-        let observe_block_2_forward =
+        let _observe_block_2_forward =
             block_misc::new_observe_block(&mut bg, copy_block_3, Observe::Forward, Some(6.0))
                 .unwrap();
-        let observe_block_3_forward =
+        let _observe_block_3_forward =
             block_misc::new_observe_block(&mut bg, copy_block_4, Observe::Forward, Some(7.0))
                 .unwrap();
         bg.finalize();
@@ -1053,7 +1053,7 @@ mod tests {
             ]
         ); // backward part  (5+6+7)
 
-        spredict2(&mut bg, &fb, &mut pb, false);
+        spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(
             pb.observations,
             vec![
@@ -1067,11 +1067,11 @@ mod tests {
 
     #[test]
     fn test_join_1_block() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block_1 = block_misc::new_const_block(&mut bg, vec![2.0, 3.0]).unwrap();
         let join_block = new_join_block(&mut bg, vec![input_block_1]).unwrap();
-        let observe_block =
+        let _observe_block =
             block_misc::new_observe_block(&mut bg, join_block, Observe::Forward, Some(6.0))
                 .unwrap();
         bg.finalize();
@@ -1082,18 +1082,18 @@ mod tests {
         slearn2(&mut bg, &fb, &mut pb, true);
         assert_eq!(pb.observations, vec![2.0, 3.0,]); // join actually doesn't do anything
 
-        spredict2(&mut bg, &fb, &mut pb, false);
+        spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(pb.observations, vec![2.0, 3.0,]); // join actually doesn't do anything
     }
 
     #[test]
     fn test_join_2_blocks() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block_1 = block_misc::new_const_block(&mut bg, vec![2.0, 3.0]).unwrap();
         let input_block_2 = block_misc::new_const_block(&mut bg, vec![4.0, 5.0, 6.0]).unwrap();
         let join_block = new_join_block(&mut bg, vec![input_block_1, input_block_2]).unwrap();
-        let observe_block =
+        let _observe_block =
             block_misc::new_observe_block(&mut bg, join_block, Observe::Forward, Some(6.0))
                 .unwrap();
         bg.finalize();
@@ -1104,20 +1104,20 @@ mod tests {
         slearn2(&mut bg, &fb, &mut pb, true);
         assert_eq!(pb.observations, vec![2.0, 3.0, 4.0, 5.0, 6.0]); // join actually doesn't do anything
 
-        spredict2(&mut bg, &fb, &mut pb, false);
+        spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(pb.observations, vec![2.0, 3.0, 4.0, 5.0, 6.0]); // join actually doesn't do anything
     }
 
     #[test]
     fn test_join_3_blocks() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block_3 = block_misc::new_const_block(&mut bg, vec![1.0, 2.0]).unwrap();
         let input_block_2 = block_misc::new_const_block(&mut bg, vec![3.0, 4.0, 5.0]).unwrap();
         let input_block_1 = block_misc::new_const_block(&mut bg, vec![6.0, 7.0]).unwrap();
         let join_block =
             new_join_block(&mut bg, vec![input_block_1, input_block_2, input_block_3]).unwrap();
-        let observe_block =
+        let _observe_block =
             block_misc::new_observe_block(&mut bg, join_block, Observe::Forward, Some(6.0))
                 .unwrap();
         bg.finalize();
@@ -1129,20 +1129,20 @@ mod tests {
         // Order depends on the input parameters order, not on order of adding to graph
         assert_eq!(pb.observations, vec![6.0, 7.0, 3.0, 4.0, 5.0, 1.0, 2.0]); // join actually doesn't do anything
 
-        spredict2(&mut bg, &fb, &mut pb, false);
+        spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(pb.observations, vec![6.0, 7.0, 3.0, 4.0, 5.0, 1.0, 2.0]); // join actually doesn't do anything
     }
 
     #[test]
     fn test_join_cascading() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block_1 = block_misc::new_const_block(&mut bg, vec![1.0, 2.0]).unwrap();
         let input_block_2 = block_misc::new_const_block(&mut bg, vec![3.0, 4.0, 5.0]).unwrap();
         let join_block_1 = new_join_block(&mut bg, vec![input_block_1, input_block_2]).unwrap();
         let input_block_3 = block_misc::new_const_block(&mut bg, vec![6.0, 7.0]).unwrap();
         let join_block_2 = new_join_block(&mut bg, vec![input_block_3, join_block_1]).unwrap();
-        let observe_block =
+        let _observe_block =
             block_misc::new_observe_block(&mut bg, join_block_2, Observe::Forward, Some(6.0))
                 .unwrap();
         bg.finalize();
@@ -1154,13 +1154,13 @@ mod tests {
         // Order depends on the input parameters order, not on order of adding to graph
         assert_eq!(pb.observations, vec![6.0, 7.0, 1.0, 2.0, 3.0, 4.0, 5.0]); // join actually doesn't do anything
 
-        spredict2(&mut bg, &fb, &mut pb, false);
+        spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(pb.observations, vec![6.0, 7.0, 1.0, 2.0, 3.0, 4.0, 5.0]); // join actually doesn't do anything
     }
 
     #[test]
     fn test_copy_to_join() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block_1 = block_misc::new_const_block(&mut bg, vec![2.0, 3.0]).unwrap();
         let observe_block_backward =
@@ -1168,7 +1168,7 @@ mod tests {
         let (copy_1, copy_2) =
             block_misc::new_copy_block_2(&mut bg, observe_block_backward).unwrap();
         let join_block = new_join_block(&mut bg, vec![copy_1, copy_2]).unwrap();
-        let observe_block =
+        let _observe_block =
             block_misc::new_observe_block(&mut bg, join_block, Observe::Forward, Some(6.0))
                 .unwrap();
         bg.finalize();
@@ -1179,7 +1179,7 @@ mod tests {
         slearn2(&mut bg, &fb, &mut pb, true);
         assert_eq!(pb.observations, vec![2.0, 3.0, 2.0, 3.0, 12.0, 12.0]); // correct backwards pass
 
-        spredict2(&mut bg, &fb, &mut pb, false);
+        spredict2(&mut bg, &fb, &mut pb);
         assert_eq!(pb.observations, vec![2.0, 3.0, 2.0, 3.0, 2.0, 3.0]); // on backward pass this are leftovers
     }
 }

--- a/src/block_neural.rs
+++ b/src/block_neural.rs
@@ -481,13 +481,6 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockNeuronLayer<L> {
         )?;
         Ok(())
     }
-
-    /// Sets internal state of weights based on some completely object-dependent parameters
-    fn testing_set_weights(&mut self, index: usize, w: &[f32]) -> Result<(), Box<dyn Error>> {
-        self.weights[index] = w[0];
-        self.weights_optimizer[index].optimizer_data = self.optimizer.initial_data();
-        Ok(())
-    }
 }
 
 mod tests {

--- a/src/block_normalize.rs
+++ b/src/block_normalize.rs
@@ -31,7 +31,7 @@ pub fn new_normalize_layer_block(
 ) -> Result<graph::BlockPtrOutput, Box<dyn Error>> {
     let num_inputs = bg.get_num_output_values(vec![&input]);
     assert_ne!(num_inputs, 0);
-    let mut block = Box::new(BlockNormalize {
+    let block = Box::new(BlockNormalize {
         output_offset: usize::MAX,
         input_offset: usize::MAX,
         num_inputs,

--- a/src/block_relu.rs
+++ b/src/block_relu.rs
@@ -26,7 +26,7 @@ pub fn new_relu_block(
 ) -> Result<graph::BlockPtrOutput, Box<dyn Error>> {
     let num_inputs = bg.get_num_output_values(vec![&input]);
     assert_ne!(num_inputs, 0);
-    let mut block = Box::new(BlockRELU {
+    let block = Box::new(BlockRELU {
         output_offset: usize::MAX,
         input_offset: usize::MAX,
         num_inputs,
@@ -154,11 +154,11 @@ mod tests {
 
     #[test]
     fn test_simple_positive() {
-        let mut mi = model_instance::ModelInstance::new_empty().unwrap();
+        let mi = model_instance::ModelInstance::new_empty().unwrap();
         let mut bg = BlockGraph::new();
         let input_block = block_misc::new_const_block(&mut bg, vec![2.0]).unwrap();
         let relu_block = new_relu_block(&mut bg, &mi, input_block).unwrap();
-        let observe_block =
+        let _observe_block =
             block_misc::new_observe_block(&mut bg, relu_block, Observe::Forward, Some(1.0))
                 .unwrap();
         bg.finalize();

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -46,7 +46,7 @@ impl<W: Write> Drop for Wrapper<W> {
     fn drop(&mut self) {
         match self.s.take() {
             Some(s) => {
-                let a = s.finish();
+                let _result = s.finish();
             }
             None => {}
         }

--- a/src/feature_transform_executor.rs
+++ b/src/feature_transform_executor.rs
@@ -204,7 +204,6 @@ impl TransformExecutors {
         namespace_transforms: &feature_transform_parser::NamespaceTransforms,
     ) -> TransformExecutors {
         let mut executors: Vec<TransformExecutor> = Vec::new();
-        let mut namespaces_to: Vec<ExecutorToNamespace> = Vec::new();
         for transformed_namespace in &namespace_transforms.v {
             let transformed_namespace_executor =
                 TransformExecutor::from_namespace_transform(transformed_namespace).unwrap();

--- a/src/feature_transform_implementations.rs
+++ b/src/feature_transform_implementations.rs
@@ -44,7 +44,7 @@ impl FunctionExecutorTrait for FunctionExampleSqrt {
 
 impl FunctionExampleSqrt {
     fn create_function(
-        function_name: &str,
+        _function_name: &str,
         from_namespaces: &Vec<feature_transform_parser::Namespace>,
         function_params: &Vec<f32>,
     ) -> Result<Box<dyn FunctionExecutorTrait>, Box<dyn Error>> {
@@ -211,7 +211,7 @@ impl FunctionExecutorTrait for TransformerLogRatioBinner {
         &self,
         record_buffer: &[u32],
         to_namespace: &mut ExecutorToNamespace,
-        transform_executors: &TransformExecutors,
+        _transform_executors: &TransformExecutors,
     ) {
         feature_reader_float_namespace!(
             record_buffer,
@@ -591,12 +591,6 @@ mod tests {
     use super::*;
     use crate::feature_transform_executor::default_seeds;
     use crate::parser::{IS_NOT_SINGLE_MASK, MASK31};
-
-    fn add_header(v2: Vec<u32>) -> Vec<u32> {
-        let mut rr: Vec<u32> = vec![100, 1, 1.0f32.to_bits()];
-        rr.extend(v2);
-        rr
-    }
 
     fn nd(start: u32, end: u32) -> u32 {
         (start << 16) + end

--- a/src/feature_transform_parser.rs
+++ b/src/feature_transform_parser.rs
@@ -11,8 +11,6 @@ use std::io::ErrorKind;
 
 use crate::feature_transform_executor;
 
-pub const TRANSFORM_NAMESPACE_MARK: u32 = 1 << 31;
-
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct Namespace {
     pub namespace_descriptor: vwmap::NamespaceDescriptor,
@@ -441,7 +439,7 @@ C,featureC,f32
         {
             let mut nstp = NamespaceTransformsParser::new();
             let result = nstp.add_transform_namespace(&vw, "featureA=Combine(featureA,featureB)()"); // unknown function
-            let nst = nstp.resolve(&vw).unwrap();
+            let _nst = nstp.resolve(&vw).unwrap();
             assert!(result.is_err());
             assert_eq!(format!("{:?}", result), "Err(Custom { kind: Other, error: \"To namespace of featureA=Combine(featureA,featureB)() already exists as primitive namespace: \\\"featureA\\\"\" })");
         }
@@ -449,6 +447,7 @@ C,featureC,f32
         {
             let mut nstp = NamespaceTransformsParser::new();
             let result = nstp.add_transform_namespace(&vw, "new=Combine(featureA,featureA)()"); // unknown function
+            assert!(result.is_ok());
             let result = nstp.resolve(&vw);
             assert!(result.is_err());
             assert_eq!(format!("{:?}", result), "Err(Custom { kind: Other, error: \"Using the same from namespace in multiple arguments to a function is not supported: \\\"featureA\\\"\" })");
@@ -588,21 +587,21 @@ C,featureC,f32
         assert_eq!(r.unwrap().1, fv);
 
         let r = parse_namespace_statement("a=sqrt(B)(3,1,2.0)");
-        let (o, rw) = r.unwrap();
+        let (_, rw) = r.unwrap();
         assert_eq!(rw.0, "a");
         assert_eq!(rw.1, "sqrt");
         assert_eq!(rw.2, vec!["B"]);
         assert_eq!(rw.3, vec![3f32, 1f32, 2.0]);
 
         let r = parse_namespace_statement("abc=sqrt(BDE,CG)(3,1,2.0)");
-        let (o, rw) = r.unwrap();
+        let (_, rw) = r.unwrap();
         assert_eq!(rw.0, "abc");
         assert_eq!(rw.1, "sqrt");
         assert_eq!(rw.2, vec!["BDE", "CG"]);
         assert_eq!(rw.3, vec![3f32, 1f32, 2.0]);
 
         let r = parse_namespace_statement("a_bcw=s_qrt(_BD_E_,C_G)(3,1,2.0)");
-        let (o, rw) = r.unwrap();
+        let (_, rw) = r.unwrap();
         assert_eq!(rw.0, "a_bcw");
         assert_eq!(rw.1, "s_qrt");
         assert_eq!(rw.2, vec!["_BD_E_", "C_G"]);

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -101,7 +101,7 @@ impl BlockGraph {
 
     pub fn add_node(
         &mut self,
-        mut block: Box<dyn BlockTrait>,
+        block: Box<dyn BlockTrait>,
         edges_in: Vec<BlockPtrOutput>,
     ) -> Result<Vec<BlockPtrOutput>, Box<dyn Error>> {
         // Due to how CopyBlock works (zero-copy first ouptut), it's first output cannot go to a Join block since join block needs to control its inputs
@@ -151,7 +151,7 @@ impl BlockGraph {
             let bpi = BlockPtrInput(bp, bi);
             self.nodes[e.get_node_id()].edges_out[e.get_output_index()] = bpi;
         }
-        let mut newnode = BlockGraphNode {
+        let newnode = BlockGraphNode {
             edges_in,
             edges_out: Vec::new(),
         };
@@ -331,7 +331,7 @@ mod tests {
         assert_eq!(bg.nodes[0].edges_out, vec![BLOCK_PTR_INPUT_DEFAULT]);
 
         // Let's add one result block
-        let output_node =
+        let _output_node =
             block_misc::new_observe_block(&mut bg, const_block_output, Observe::Forward, Some(1.0))
                 .unwrap();
 
@@ -364,7 +364,7 @@ mod tests {
         let (c1, c2) = block_misc::new_copy_block_2(&mut bg, const_block_output).unwrap();
 
         // Let's add one result block
-        let output_node =
+        let _output_node =
             block_misc::new_observe_block(&mut bg, c1, Observe::Forward, Some(1.0)).unwrap();
 
         assert_eq!(bg.nodes[0].edges_in.len(), 0);
@@ -375,9 +375,8 @@ mod tests {
 
         // Let's add second result block to see what happens
 
-        let output_node =
+        let _output_node =
             block_misc::new_observe_block(&mut bg, c2, Observe::Forward, Some(1.0)).unwrap();
-        //        assert_eq!(output_node, ());
         assert_eq!(bg.nodes[0].edges_in, vec![]);
         assert_eq!(
             bg.nodes[0].edges_out,
@@ -430,7 +429,7 @@ mod tests {
         assert_eq!(bg.nodes[1].edges_out, vec![BLOCK_PTR_INPUT_DEFAULT]);
 
         // Using the join block, we merge two outputs into one single output (copy-less implementation)
-        let mut union_output =
+        let union_output =
             block_misc::new_join_block(&mut bg, vec![const_block_output1, const_block_output2])
                 .unwrap();
         assert_eq!(union_output, BlockPtrOutput(BlockPtr(2), OutputSlot(0)));
@@ -461,10 +460,9 @@ mod tests {
         let mut bg = BlockGraph::new();
 
         let const_block_output = block_misc::new_const_block(&mut bg, vec![1.0]).unwrap();
-        let output_node =
+        let _output_node =
             block_misc::new_observe_block(&mut bg, const_block_output, Observe::Forward, Some(1.0))
                 .unwrap();
-        //        assert_eq!(output_node, ());
         bg.finalize();
         assert_eq!(bg.tape_size, 1);
     }
@@ -487,7 +485,7 @@ mod tests {
         let re_lr = block_lr::new_lr_block(&mut bg, &mi).unwrap();
         let re_ffm = block_ffm::new_ffm_block(&mut bg, &mi).unwrap();
         let joined = block_misc::new_join_block(&mut bg, vec![re_lr, re_ffm]).unwrap();
-        let lossf = block_loss_functions::new_logloss_block(&mut bg, joined, true);
+        let _lossf = block_loss_functions::new_logloss_block(&mut bg, joined, true);
         bg.finalize();
     }
 
@@ -506,13 +504,13 @@ mod tests {
         let const_4 = block_misc::new_const_block(&mut bg, vec![4.0]).unwrap(); // 3
         let (copy_output_1, copy_output_2) =
             block_misc::new_copy_block_2(&mut bg, const_1).unwrap(); // 4
-        let (copy_output_3, copy_output_4) =
+        let (_copy_output_3, _copy_output_4) =
             block_misc::new_copy_block_2(&mut bg, const_2).unwrap(); // 5
 
         // this is not zero copy
-        let join_1 = block_misc::new_join_block(&mut bg, vec![copy_output_1, const_3]).unwrap(); // 6
-                                                                                                 // this is zero copy
-        let join_2 = block_misc::new_join_block(&mut bg, vec![const_4, copy_output_2]); // 7
+        let _join_1 = block_misc::new_join_block(&mut bg, vec![copy_output_1, const_3]).unwrap(); // 6
+                                                                                                  // this is zero copy
+        let _join_2 = block_misc::new_join_block(&mut bg, vec![const_4, copy_output_2]); // 7
         bg.finalize();
         let mut list = bg.take_blocks();
 
@@ -546,9 +544,8 @@ mod tests {
         let const_1 = block_misc::new_const_block(&mut bg, vec![1.0]).unwrap();
         let const_2 = block_misc::new_const_block(&mut bg, vec![1.0]).unwrap();
         let const_3 = block_misc::new_const_block(&mut bg, vec![1.0]).unwrap();
-        let mut join_block1 = block_misc::new_join_block(&mut bg, vec![const_1, const_2]).unwrap();
-        let mut join_block2 =
-            block_misc::new_join_block(&mut bg, vec![join_block1, const_3]).unwrap();
+        let join_block1 = block_misc::new_join_block(&mut bg, vec![const_1, const_2]).unwrap();
+        let _join_block2 = block_misc::new_join_block(&mut bg, vec![join_block1, const_3]).unwrap();
         assert_eq!(bg.nodes.len(), 5);
         assert_eq!(bg.nodes[3].edges_in.len(), 0); // 3 is the first join block which was removed
         assert_eq!(bg.nodes[3].edges_out.len(), 0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl Predictor {
             &mut self.cache.blocks,
             is_empty,
         );
-        return 0.0;
+        0.0
     }
 }
 

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -196,7 +196,7 @@ impl ModelInstance {
             let weight_str = vsplit[1];
             combo_weight = match weight_str.parse() {
                 Ok(x) => x,
-                Err(y) => {
+                Err(_) => {
                     return Err(Box::new(IOError::new(
                         ErrorKind::Other,
                         format!(
@@ -427,7 +427,7 @@ impl ModelInstance {
 
         if let Some(val) = cl.value_of("nn_layers") {
             let nn_layers = val.parse()?;
-            for i in 0..nn_layers {
+            for _ in 0..nn_layers {
                 mi.nn_config.layers.push(HashMap::new());
             }
         }
@@ -673,8 +673,7 @@ C,featureC
     fn test_nn_parsing() {
         let mut mi = ModelInstance::new_empty().unwrap();
 
-        let LAYERS = 4;
-        for i in 0..LAYERS {
+        for _ in 0..4 {
             mi.nn_config.layers.push(HashMap::new());
         }
         assert!(mi.parse_nn("1:foo:bar").is_ok());

--- a/src/multithread_helpers.rs
+++ b/src/multithread_helpers.rs
@@ -42,7 +42,7 @@ impl<T: Sized> Drop for UnsafelySharableTrait<T> {
             // we are called before reference is removed, so we need to decide if to drop it or not
             let count = Arc::<Mutex<PhantomData<u32>>>::strong_count(&self.reference_count) - 1;
             if count == 0 {
-                let box_to_be_dropped = ManuallyDrop::take(&mut self.content);
+                let _box_to_be_dropped = ManuallyDrop::take(&mut self.content);
                 // Now this means that the content will be dropped
             }
         }

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -193,7 +193,7 @@ mod tests {
             assert_eq!(acc, 0.1 * 0.1);
 
             acc = 0.0;
-            let p = l.calculate_update(0.0, &mut acc);
+            l.calculate_update(0.0, &mut acc);
             // Here we check that we get NaN back - this is not good, but it's correct
             //            assert!(p.is_nan());
             assert_eq!(acc, 0.0);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -212,7 +212,7 @@ impl VowpalParser {
     }
 
     fn next_vowpal_to_size(&mut self, tmp_read_buf_size: usize) -> Result<&[u32], Box<dyn Error>> {
-        let bufpos: usize = (self.vw_map.num_namespaces + HEADER_LEN as usize) as usize;
+        let bufpos: usize = self.vw_map.num_namespaces + HEADER_LEN as usize;
 
         let mut current_namespace_num_of_features = 0;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -958,7 +958,6 @@ C,featureC
         assert!(result.is_err());
         assert_eq!(format!("{:?}", result), "Err(Custom { kind: Other, error: \"Namespaces that are f32 can not have weight attached neither to namespace nor to a single feature (basically they can\' use :weight syntax\" })");
 
-        let mut buf = str_to_cursor("-1 |B NONE\n");
         // Now test with skip_prefix = 1
         let vw_map_string = r#"
 A,featureA

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -195,7 +195,9 @@ mod tests {
     use regressor::BlockTrait;
     use regressor::Regressor;
 
+    use crate::optimizer::OptimizerTrait;
     use tempfile::tempdir;
+
     #[test]
     fn save_empty_model() {
         let vw_map_string = r#"
@@ -299,7 +301,8 @@ B,featureB
 
         for i in 0..block_ffm.get_serialized_len() {
             // it only happens that this matches number of weights
-            block_ffm.testing_set_weights(i, &[1.0f32]).unwrap();
+            block_ffm.weights[i] = 1.0;
+            block_ffm.optimizer[i].optimizer_data = block_ffm.optimizer_ffm.initial_data();
         }
     }
 

--- a/src/radix_tree.rs
+++ b/src/radix_tree.rs
@@ -53,7 +53,7 @@ impl RadixTree {
 
         for &byte in key {
             let child = &mut node.children[byte as usize];
-            node = child.get_or_insert_with(|| RadixTreeNode::new());
+            node = child.get_or_insert_with(RadixTreeNode::new);
         }
 
         node.value = Some(value);

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -118,11 +118,6 @@ pub trait BlockTrait {
     ) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
-
-    /// Sets internal state of weights based on some completely object-dependent parameters
-    fn testing_set_weights(&mut self, _index: usize, _w: &[f32]) -> Result<(), Box<dyn Error>> {
-        Ok(())
-    }
 }
 
 pub struct Regressor {

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -75,7 +75,7 @@ pub trait BlockTrait {
         block_helpers::create_forward_cache(further_blocks, caches);
     }
 
-    fn allocate_and_init_weights(&mut self, mi: &model_instance::ModelInstance) {}
+    fn allocate_and_init_weights(&mut self, _mi: &model_instance::ModelInstance) {}
 
     fn get_serialized_len(&self) -> usize {
         0
@@ -83,48 +83,44 @@ pub trait BlockTrait {
 
     fn write_weights_to_buf(
         &self,
-        output_bufwriter: &mut dyn io::Write,
+        _output_bufwriter: &mut dyn io::Write,
     ) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
 
     fn read_weights_from_buf(
         &mut self,
-        input_bufreader: &mut dyn io::Read,
+        _input_bufreader: &mut dyn io::Read,
     ) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
-    fn get_num_output_values(&self, output: graph::OutputSlot) -> usize;
+    fn get_num_output_values(&self, _output: graph::OutputSlot) -> usize;
 
     fn get_num_output_slots(&self) -> usize {
         1
     }
 
-    fn get_input_offset(&mut self, input: graph::InputSlot) -> Result<usize, Box<dyn Error>> {
+    fn get_input_offset(&mut self, _input: graph::InputSlot) -> Result<usize, Box<dyn Error>> {
         Err("get_input_offset() is only supported by CopyBlock".to_string())?
     }
-    fn set_input_offset(&mut self, input: graph::InputSlot, offset: usize) {}
-    fn set_output_offset(&mut self, output: graph::OutputSlot, offset: usize) {}
+
+    fn set_input_offset(&mut self, _input: graph::InputSlot, _offset: usize) {}
+    fn set_output_offset(&mut self, _output: graph::OutputSlot, _offset: usize) {}
+
     fn get_block_type(&self) -> graph::BlockType {
         graph::BlockType::Regular
     }
 
     fn read_weights_from_buf_into_forward_only(
         &self,
-        input_bufreader: &mut dyn io::Read,
-        forward: &mut Box<dyn BlockTrait>,
+        _input_bufreader: &mut dyn io::Read,
+        _forward: &mut Box<dyn BlockTrait>,
     ) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
 
     /// Sets internal state of weights based on some completely object-dependent parameters
-    fn testing_set_weights(
-        &mut self,
-        aa: i32,
-        bb: i32,
-        index: usize,
-        w: &[f32],
-    ) -> Result<(), Box<dyn Error>> {
+    fn testing_set_weights(&mut self, _index: usize, _w: &[f32]) -> Result<(), Box<dyn Error>> {
         Ok(())
     }
 }
@@ -173,8 +169,8 @@ impl Regressor {
         let mut output = block_lr::new_lr_block(&mut bg, mi).unwrap();
 
         if mi.ffm_k > 0 {
-            let mut block_ffm = block_ffm::new_ffm_block(&mut bg, mi).unwrap();
-            let mut triangle_ffm = block_misc::new_triangle_block(&mut bg, block_ffm).unwrap();
+            let block_ffm = block_ffm::new_ffm_block(&mut bg, mi).unwrap();
+            let triangle_ffm = block_misc::new_triangle_block(&mut bg, block_ffm).unwrap();
             output = block_misc::new_join_block(&mut bg, vec![output, triangle_ffm]).unwrap();
         }
 
@@ -191,13 +187,6 @@ impl Regressor {
                 output = a1;
                 join_block = Some(a2);
                 output = block_normalize::new_normalize_layer_block(&mut bg, mi, output).unwrap();
-
-                /*let (a1, a2) = block_misc::new_copy_block_2(&mut bg, output).unwrap();
-                output = a1;
-                join_block = Some(a2);
-                let mut lr_block_1 = block_lr::new_lr_block(&mut bg, mi).unwrap();
-                let mut lr_block_2 = block_lr::new_lr_block(&mut bg, mi).unwrap();
-                output = block_misc::new_join_block(&mut bg, vec![output, lr_block_1, lr_block_2]).unwrap();*/
             } else if mi.nn_config.topology == "five" {
                 let (a1, a2) = block_misc::new_copy_block_2(&mut bg, output).unwrap();
                 output = a1;
@@ -236,7 +225,7 @@ impl Regressor {
                     .unwrap_or("0.0".to_string())
                     .parse()
                     .unwrap();
-                //let layernorm: bool = layer.remove("layernorm").unwrap_or("false".to_string()).parse().unwrap();
+
                 let init_type_str: String =
                     layer.remove("init").unwrap_or("hu".to_string()).to_string();
 
@@ -276,8 +265,6 @@ impl Regressor {
                     .unwrap(),
                 };
                 let neuron_type = block_neural::NeuronType::WeightedSum;
-                // println!("Neuron layer: width: {}, neuron type: {:?}, dropout: {}, maxnorm: {}, init_type: {:?}",
-                //                        width, neuron_type, dropout, maxnorm, init_type);
                 output = block_neural::new_neuronlayer_block(
                     &mut bg,
                     mi,
@@ -319,14 +306,11 @@ impl Regressor {
         }
 
         // now sigmoid has a single input
-        let lossf = block_loss_functions::new_logloss_block(&mut bg, output, true).unwrap();
+        let _lossf = block_loss_functions::new_logloss_block(&mut bg, output, true).unwrap();
         bg.finalize();
         rg.tape_len = bg.get_tape_size();
 
         rg.blocks_boxes = bg.take_blocks();
-        /*for (i, block) in bg.blocks.into_iter().enumerate() {
-            rg.blocks_boxes.push(block);
-        }*/
 
         rg
     }
@@ -408,9 +392,7 @@ impl Regressor {
         block_helpers::forward_with_cache(further_blocks, fb, pb, caches);
 
         assert_eq!(pb.observations.len(), 1);
-        let prediction_probability = pb.observations.pop().unwrap();
-
-        return prediction_probability;
+        pb.observations.pop().unwrap()
     }
 
     pub fn setup_cache(

--- a/src/serving.rs
+++ b/src/serving.rs
@@ -374,10 +374,9 @@ C,featureC
         mi.ffm_learning_rate = 0.1;
         mi.ffm_fields = vec![vec![], vec![]];
         mi.optimizer = model_instance::Optimizer::AdagradLUT;
-        let mut re_1 = regressor::Regressor::new(&mi);
+        let re_1 = regressor::Regressor::new(&mi);
         mi.optimizer = model_instance::Optimizer::SGD;
-        let mut re_2 = regressor::Regressor::new(&mi);
-        let mut p: f32;
+        let re_2 = regressor::Regressor::new(&mi);
 
         let dir = tempdir().unwrap();
         let regressor_filepath_1 = dir


### PR DESCRIPTION
We are left with only 9 warnings on the bin, where 8 of them are

```
warning: the type `[f32; 131072]` does not permit being left uninitialized
   --> src/block_ffm.rs:286:21
    |
286 |                     MaybeUninit::uninit().assume_init();
    |                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |                     |
    |                     this code causes undefined behavior when executed
    |                     help: use `MaybeUninit<T>` instead, and only call `assume_init` after initialization is done
    |
    = note: floats must be initialized
    = note: `#[warn(invalid_value)]` on by default
```
     
     
 & the last one is  
```
warning: value assigned to `buffer` is never read
   --> src/main.rs:113:13
    |
113 |             buffer = match reading_result {
    |             ^^^^^^
    |
    = help: maybe it is overwritten before being read?
    = note: `#[warn(unused_assignments)]` on by default
```

On the lib creation there are a bit more, but they are not relevant as the highlighted sections of code are marked as unused, while they are used by the bin & not the lib.