### PR TITLE
Cache rewrite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ blas = "0.22.0"
 intel-mkl-src = {version= "0.8.1", default-features = false, features=["mkl-static-lp64-seq"]}
 log = "0.4.18"
 env_logger = "0.10.0"
+rustc-hash = "1.1.0"
 
 [build-dependencies]
 cbindgen = "0.23.0"

--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -7,10 +7,6 @@ use std::sync::Mutex;
 
 use merand48::*;
 
-docker-client hadoop fs -rm /user/hadoop/outbrain/summary/ctr_models/fw-gg-cache-opt/archive/date=2023-08-21/time=19-20/production_model_instance.json --force-dc=nydc1
-
-VOLUME_PATH=$PWD docker-client hadoop fs -put $PWD/production_model_instance.json /user/hadoop/outbrain/summary/ctr_models/fw-gg-cache-opt/archive/date=2023-08-21/time=19-20/production_model_instance.json --force-dc=chidc2
-
 use optimizer::OptimizerTrait;
 use regressor::BlockTrait;
 

--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -1,6 +1,6 @@
 use core::arch::x86_64::*;
+use rustc_hash::FxHashSet;
 use std::any::Any;
-use std::collections::HashSet;
 use std::error::Error;
 use std::io;
 use std::mem::{self, MaybeUninit};
@@ -603,7 +603,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
         unsafe {
             caches.push(BlockCache::FFM {
                 contra_fields: MaybeUninit::uninit().assume_init(),
-                features_present: HashSet::with_capacity(self.ffm_num_fields as usize),
+                features_present: FxHashSet::default(),
                 ffm: vec![0.0; (self.ffm_num_fields * self.ffm_num_fields) as usize],
             });
         }

--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -493,7 +493,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
             for field_index in 0..ffm_fields_count {
                 let field_index_ffmk = field_index * ffmk;
                 let field_index_ffmk_as_usize = field_index_ffmk as usize;
-                let offset = (field_index_ffmk * ffm_fields_count) as usize;
+                let offset = (field_index_ffmk_as_usize * ffm_fields_count_as_usize);
                 // first we handle fields with no features
                 if ffm_buffer_index >= fb.ffm_buffer.len()
                     || fb
@@ -559,7 +559,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
                     } else {
                         let feature_index = feature.hash as usize;
                         let feature_value = feature.value;
-                        // println!("feature: {:?} offset: {offset} ffm_buffer_index: {ffm_buffer_index} field_index: {field_index}", feature);
+
                         self.prepare_contra_fields(
                             feature,
                             contra_fields.as_mut_slice(),

--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -493,7 +493,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
             for field_index in 0..ffm_fields_count {
                 let field_index_ffmk = field_index * ffmk;
                 let field_index_ffmk_as_usize = field_index_ffmk as usize;
-                let offset = (field_index_ffmk_as_usize * ffm_fields_count_as_usize);
+                let offset = field_index_ffmk_as_usize * ffm_fields_count_as_usize;
                 // first we handle fields with no features
                 if ffm_buffer_index >= fb.ffm_buffer.len()
                     || fb

--- a/src/feature_buffer.rs
+++ b/src/feature_buffer.rs
@@ -172,6 +172,15 @@ impl FeatureBufferTranslator {
     }
 
     pub fn translate(&mut self, record_buffer: &[u32], example_number: u64) {
+        self.translate_and_filter(record_buffer, example_number, None);
+    }
+
+    pub fn translate_and_filter(
+        &mut self,
+        record_buffer: &[u32],
+        example_number: u64,
+        ffm_filtered_namespace_type: Option<NamespaceType>,
+    ) {
         {
             let lr_buffer = &mut self.feature_buffer.lr_buffer;
             lr_buffer.truncate(0);
@@ -274,25 +283,55 @@ impl FeatureBufferTranslator {
                 let ffm_buffer = &mut self.feature_buffer.ffm_buffer;
                 ffm_buffer.truncate(0);
 
-                for (contra_field_index, ffm_field) in
-                    self.model_instance.ffm_fields.iter().enumerate()
-                {
-                    for namespace_descriptor in ffm_field {
-                        feature_reader!(
-                            record_buffer,
-                            self.transform_executors,
-                            *namespace_descriptor,
-                            hash_index,
-                            hash_value,
-                            {
-                                ffm_buffer.push(HashAndValueAndSeq {
-                                    hash: hash_index & self.ffm_hash_mask,
-                                    value: hash_value,
-                                    contra_field_index: contra_field_index as u32
-                                        * self.model_instance.ffm_k,
-                                });
-                            }
-                        );
+                if ffm_filtered_namespace_type.is_none() {
+                    for (contra_field_index, ffm_field) in
+                        self.model_instance.ffm_fields.iter().enumerate()
+                    {
+                        for namespace_descriptor in ffm_field {
+                            feature_reader!(
+                                record_buffer,
+                                self.transform_executors,
+                                *namespace_descriptor,
+                                hash_index,
+                                hash_value,
+                                {
+                                    ffm_buffer.push(HashAndValueAndSeq {
+                                        hash: hash_index & self.ffm_hash_mask,
+                                        value: hash_value,
+                                        contra_field_index: contra_field_index as u32
+                                            * self.model_instance.ffm_k,
+                                    });
+                                }
+                            );
+                        }
+                    }
+                } else {
+                    let ffm_filtered_namespace_type = ffm_filtered_namespace_type.unwrap();
+                    for (contra_field_index, ffm_field) in
+                        self.model_instance.ffm_fields.iter().enumerate()
+                    {
+                        for namespace_descriptor in ffm_field {
+                            feature_reader!(
+                                record_buffer,
+                                self.transform_executors,
+                                *namespace_descriptor,
+                                hash_index,
+                                hash_value,
+                                {
+                                    if ffm_filtered_namespace_type
+                                        != namespace_descriptor.namespace_type
+                                    {
+                                        continue;
+                                    }
+                                    ffm_buffer.push(HashAndValueAndSeq {
+                                        hash: hash_index & self.ffm_hash_mask,
+                                        value: hash_value,
+                                        contra_field_index: contra_field_index as u32
+                                            * self.model_instance.ffm_k,
+                                    });
+                                }
+                            );
+                        }
                     }
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ use crate::multithread_helpers::BoxedRegressorTrait;
 use crate::parser::VowpalParser;
 use crate::port_buffer::PortBuffer;
 use crate::regressor::BlockCache;
+use crate::vwmap::NamespaceType;
 use shellwords;
 use std::ffi::CStr;
 use std::io::Cursor;
@@ -128,7 +129,11 @@ impl Predictor {
         };
         // ignore last newline byte
         self.cache.input_buffer_size = input_buffer_size;
-        self.feature_buffer_translator.translate(buffer, 0);
+        self.feature_buffer_translator.translate_and_filter(
+            buffer,
+            0,
+            Some(NamespaceType::Primitive),
+        );
         let is_empty = self.cache.blocks.is_empty();
         self.regressor.setup_cache(
             &self.feature_buffer_translator.feature_buffer,

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -1,5 +1,6 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::any::Any;
+use std::collections::HashSet;
 use std::error::Error;
 use std::io;
 use std::io::Cursor;
@@ -14,6 +15,7 @@ use crate::block_neural::InitType;
 use crate::block_normalize;
 use crate::block_relu;
 use crate::feature_buffer;
+use crate::feature_buffer::HashAndValueAndSeq;
 use crate::graph;
 use crate::model_instance;
 use crate::optimizer;
@@ -21,10 +23,25 @@ use crate::port_buffer;
 
 pub const FFM_CONTRA_BUF_LEN: usize = 16384;
 
+#[derive(Clone, Debug, Eq, PartialEq, Hash)]
+pub struct FFMFeature {
+    pub index: u32,
+    pub contra_field_index: u32,
+}
+
+impl From<&HashAndValueAndSeq> for FFMFeature {
+    fn from(value: &HashAndValueAndSeq) -> Self {
+        FFMFeature {
+            index: value.hash,
+            contra_field_index: value.contra_field_index,
+        }
+    }
+}
+
 pub enum BlockCache {
     FFM {
         contra_fields: [f32; FFM_CONTRA_BUF_LEN],
-        contra_fields_present: Vec<bool>,
+        features_present: HashSet<FFMFeature>,
         ffm: Vec<f32>,
     },
     LR {

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -1,6 +1,6 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
+use rustc_hash::FxHashSet;
 use std::any::Any;
-use std::collections::HashSet;
 use std::error::Error;
 use std::io;
 use std::io::Cursor;
@@ -41,7 +41,7 @@ impl From<&HashAndValueAndSeq> for FFMFeature {
 pub enum BlockCache {
     FFM {
         contra_fields: [f32; FFM_CONTRA_BUF_LEN],
-        features_present: HashSet<FFMFeature>,
+        features_present: FxHashSet<FFMFeature>,
         ffm: Vec<f32>,
     },
     LR {


### PR DESCRIPTION
Decided to re-write the cache functionality to make it more explicit and easier to follow what is happening & to prevent issues where Transformed features that were part of both the cached & non-cached part were being used as input.

Additionally also added reusable sub-methods in the FFM block that are always inlined & make the code dry-er.

This functionality was also already tested on a live system and didn't see any negative side effects both from performance and accuracy perspective.