### PR TITLE
Clippy needless_borrow and single_match warnings fixed

### DIFF
--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -383,7 +383,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
                         == field_index_ffmk
                 {
                     _mm_prefetch(
-                        mem::transmute::<&f32, &i8>(&ffm_weights.get_unchecked(
+                        mem::transmute::<&f32, &i8>(ffm_weights.get_unchecked(
                             fb.ffm_buffer.get_unchecked(ffm_buffer_index + 1).hash as usize,
                         )),
                         _MM_HINT_T0,
@@ -462,7 +462,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
             let ffm_weights = &self.weights;
             _mm_prefetch(
                 mem::transmute::<&f32, &i8>(
-                    &ffm_weights.get_unchecked(fb.ffm_buffer.get_unchecked(0).hash as usize),
+                    ffm_weights.get_unchecked(fb.ffm_buffer.get_unchecked(0).hash as usize),
                 ),
                 _MM_HINT_T0,
             );
@@ -529,7 +529,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
                         == field_index_ffmk
                 {
                     _mm_prefetch(
-                        mem::transmute::<&f32, &i8>(&ffm_weights.get_unchecked(
+                        mem::transmute::<&f32, &i8>(ffm_weights.get_unchecked(
                             fb.ffm_buffer.get_unchecked(ffm_buffer_index + 1).hash as usize,
                         )),
                         _MM_HINT_T0,
@@ -640,7 +640,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
             let ffm_weights = &self.weights;
             _mm_prefetch(
                 mem::transmute::<&f32, &i8>(
-                    &ffm_weights.get_unchecked(fb.ffm_buffer.get_unchecked(0).hash as usize),
+                    ffm_weights.get_unchecked(fb.ffm_buffer.get_unchecked(0).hash as usize),
                 ),
                 _MM_HINT_T0,
             );
@@ -689,7 +689,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
                         == field_index_ffmk
                 {
                     _mm_prefetch(
-                        mem::transmute::<&f32, &i8>(&ffm_weights.get_unchecked(
+                        mem::transmute::<&f32, &i8>(ffm_weights.get_unchecked(
                             fb.ffm_buffer.get_unchecked(ffm_buffer_index + 1).hash as usize,
                         )),
                         _MM_HINT_T0,
@@ -857,17 +857,15 @@ impl<L: OptimizerTrait + 'static> BlockFFM<L> {
                         ffm_weights.get_unchecked(feature_index + z) * feature_value;
                 }
             }
+        } else if feature_value == 1.0 {
+            for z in 0..field_embedding_len {
+                *contra_fields.get_unchecked_mut(offset + z) +=
+                    *ffm_weights.get_unchecked(feature_index + z);
+            }
         } else {
-            if feature_value == 1.0 {
-                for z in 0..field_embedding_len {
-                    *contra_fields.get_unchecked_mut(offset + z) +=
-                        *ffm_weights.get_unchecked(feature_index + z);
-                }
-            } else {
-                for z in 0..field_embedding_len {
-                    *contra_fields.get_unchecked_mut(offset + z) +=
-                        ffm_weights.get_unchecked(feature_index + z) * feature_value;
-                }
+            for z in 0..field_embedding_len {
+                *contra_fields.get_unchecked_mut(offset + z) +=
+                    ffm_weights.get_unchecked(feature_index + z) * feature_value;
             }
         }
     }

--- a/src/block_helpers.rs
+++ b/src/block_helpers.rs
@@ -214,11 +214,8 @@ pub fn forward_backward(
     pb: &mut port_buffer::PortBuffer,
     update: bool,
 ) {
-    match further_blocks.split_first_mut() {
-        Some((next_regressor, further_blocks)) => {
-            next_regressor.forward_backward(further_blocks, fb, pb, update)
-        }
-        None => {}
+    if let Some((next_regressor, further_blocks)) = further_blocks.split_first_mut() {
+        next_regressor.forward_backward(further_blocks, fb, pb, update)
     }
 }
 
@@ -241,11 +238,8 @@ pub fn forward_with_cache(
     pb: &mut port_buffer::PortBuffer,
     caches: &[BlockCache],
 ) {
-    match further_blocks.split_first() {
-        Some((next_regressor, further_blocks)) => {
-            next_regressor.forward_with_cache(further_blocks, fb, pb, caches)
-        }
-        None => {}
+    if let Some((next_regressor, further_blocks)) = further_blocks.split_first() {
+        next_regressor.forward_with_cache(further_blocks, fb, pb, caches)
     }
 }
 
@@ -255,11 +249,8 @@ pub fn prepare_forward_cache(
     fb: &feature_buffer::FeatureBuffer,
     caches: &mut [BlockCache],
 ) {
-    match further_blocks.split_first_mut() {
-        Some((next_regressor, further_blocks)) => {
-            next_regressor.prepare_forward_cache(further_blocks, fb, caches)
-        }
-        None => {}
+    if let Some((next_regressor, further_blocks)) = further_blocks.split_first_mut() {
+        next_regressor.prepare_forward_cache(further_blocks, fb, caches)
     }
 }
 
@@ -268,10 +259,7 @@ pub fn create_forward_cache(
     further_blocks: &mut [Box<dyn BlockTrait>],
     caches: &mut Vec<BlockCache>,
 ) {
-    match further_blocks.split_first_mut() {
-        Some((next_regressor, further_blocks)) => {
-            next_regressor.create_forward_cache(further_blocks, caches)
-        }
-        None => {}
+    if let Some((next_regressor, further_blocks)) = further_blocks.split_first_mut() {
+        next_regressor.create_forward_cache(further_blocks, caches)
     }
 }

--- a/src/block_misc.rs
+++ b/src/block_misc.rs
@@ -100,11 +100,8 @@ impl BlockTrait for BlockObserve {
         }
 
         // replace inputs with whatever we wanted
-        match self.replace_backward_with {
-            Some(value) => {
-                pb.tape[self.input_offset..(self.input_offset + self.num_inputs)].fill(value)
-            }
-            None => {}
+        if let Some(value) = self.replace_backward_with {
+            pb.tape[self.input_offset..(self.input_offset + self.num_inputs)].fill(value)
         }
     }
 
@@ -132,11 +129,8 @@ impl BlockTrait for BlockObserve {
         }
 
         // replace inputs with whatever we wanted
-        match self.replace_backward_with {
-            Some(value) => {
-                pb.tape[self.input_offset..(self.input_offset + self.num_inputs)].fill(value)
-            }
-            None => {}
+        if let Some(value) = self.replace_backward_with {
+            pb.tape[self.input_offset..(self.input_offset + self.num_inputs)].fill(value)
         }
     }
 
@@ -166,11 +160,8 @@ impl BlockTrait for BlockObserve {
         }
 
         // replace inputs with whatever we wanted
-        match self.replace_backward_with {
-            Some(value) => {
-                pb.tape[self.input_offset..(self.input_offset + self.num_inputs)].fill(value)
-            }
-            None => {}
+        if let Some(value) = self.replace_backward_with {
+            pb.tape[self.input_offset..(self.input_offset + self.num_inputs)].fill(value)
         }
     }
 }

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -44,11 +44,8 @@ impl<W: io::Write> Write for Wrapper<W> {
 }
 impl<W: Write> Drop for Wrapper<W> {
     fn drop(&mut self) {
-        match self.s.take() {
-            Some(s) => {
-                let _result = s.finish();
-            }
-            None => {}
+        if let Some(s) = self.s.take() {
+            let _result = s.finish();
         }
     }
 }
@@ -69,14 +66,9 @@ pub struct RecordCache {
 
 impl RecordCache {
     pub fn new(input_filename: &str, enabled: bool, vw_map: &vwmap::VwNamespaceMap) -> RecordCache {
-        let gz: bool;
         let temporary_filename: String = format!("{}.fwcache.writing", input_filename);
         let final_filename: String = format!("{}.fwcache", input_filename);
-        if !input_filename.ends_with("gz") {
-            gz = false;
-        } else {
-            gz = true;
-        }
+        let gz = input_filename.ends_with("gz");
 
         let mut rc = RecordCache {
             output_bufwriter: Box::new(io::BufWriter::new(io::sink())),

--- a/src/feature_buffer.rs
+++ b/src/feature_buffer.rs
@@ -283,30 +283,7 @@ impl FeatureBufferTranslator {
                 let ffm_buffer = &mut self.feature_buffer.ffm_buffer;
                 ffm_buffer.truncate(0);
 
-                if ffm_filtered_namespace_type.is_none() {
-                    for (contra_field_index, ffm_field) in
-                        self.model_instance.ffm_fields.iter().enumerate()
-                    {
-                        for namespace_descriptor in ffm_field {
-                            feature_reader!(
-                                record_buffer,
-                                self.transform_executors,
-                                *namespace_descriptor,
-                                hash_index,
-                                hash_value,
-                                {
-                                    ffm_buffer.push(HashAndValueAndSeq {
-                                        hash: hash_index & self.ffm_hash_mask,
-                                        value: hash_value,
-                                        contra_field_index: contra_field_index as u32
-                                            * self.model_instance.ffm_k,
-                                    });
-                                }
-                            );
-                        }
-                    }
-                } else {
-                    let ffm_filtered_namespace_type = ffm_filtered_namespace_type.unwrap();
+                if let Some(ffm_filtered_namespace_type) = ffm_filtered_namespace_type {
                     for (contra_field_index, ffm_field) in
                         self.model_instance.ffm_fields.iter().enumerate()
                     {
@@ -323,6 +300,28 @@ impl FeatureBufferTranslator {
                                     {
                                         continue;
                                     }
+                                    ffm_buffer.push(HashAndValueAndSeq {
+                                        hash: hash_index & self.ffm_hash_mask,
+                                        value: hash_value,
+                                        contra_field_index: contra_field_index as u32
+                                            * self.model_instance.ffm_k,
+                                    });
+                                }
+                            );
+                        }
+                    }
+                } else {
+                    for (contra_field_index, ffm_field) in
+                        self.model_instance.ffm_fields.iter().enumerate()
+                    {
+                        for namespace_descriptor in ffm_field {
+                            feature_reader!(
+                                record_buffer,
+                                self.transform_executors,
+                                *namespace_descriptor,
+                                hash_index,
+                                hash_value,
+                                {
                                     ffm_buffer.push(HashAndValueAndSeq {
                                         hash: hash_index & self.ffm_hash_mask,
                                         value: hash_value,

--- a/src/main.rs
+++ b/src/main.rs
@@ -317,13 +317,10 @@ fn main2() -> Result<(), Box<dyn Error>> {
         let elapsed = now.elapsed();
         log::info!("Elapsed: {:.2?} rows: {}", elapsed, example_num);
 
-        if let Some(filename) = final_regressor_filename { persistence::save_sharable_regressor_to_filename(
-            filename,
-            &mi,
-            &vw,
-            sharable_regressor,
-            )
-            .unwrap() }
+        if let Some(filename) = final_regressor_filename {
+            persistence::save_sharable_regressor_to_filename(filename, &mi, &vw, sharable_regressor)
+                .unwrap()
+        }
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,12 +58,9 @@ mod vwmap;
 fn main() {
     logging_layer::initialize_logging_layer();
 
-    match main2() {
-        Err(e) => {
-            log::error!("Global error: {:?}", e);
-            std::process::exit(1)
-        }
-        Ok(()) => {}
+    if let Err(e) = main2() {
+        log::error!("Global error: {:?}", e);
+        std::process::exit(1)
     }
 }
 
@@ -140,22 +137,16 @@ fn main2() -> Result<(), Box<dyn Error>> {
 
     let final_regressor_filename = cl.value_of("final_regressor");
     let output_pred_sto: bool = cl.is_present("predictions_stdout");
-    match final_regressor_filename {
-        Some(filename) => {
-            if !cl.is_present("save_resume") {
-                return Err("You need to use --save_resume with --final_regressor, for vowpal wabbit compatibility")?;
-            }
-            log::info!("final_regressor = {}", filename);
+    if let Some(filename) = final_regressor_filename {
+        if !cl.is_present("save_resume") {
+            return Err("You need to use --save_resume with --final_regressor, for vowpal wabbit compatibility")?;
         }
-        None => {}
+        log::info!("final_regressor = {}", filename);
     };
 
     let inference_regressor_filename = cl.value_of("convert_inference_regressor");
-    match inference_regressor_filename {
-        Some(filename1) => {
-            log::info!("inference_regressor = {}", filename1);
-        }
-        None => {}
+    if let Some(filename) = inference_regressor_filename {
+        log::info!("inference_regressor = {}", filename);
     };
 
     /* setting up the pipeline, either from command line or from existing regressor */
@@ -178,11 +169,8 @@ fn main2() -> Result<(), Box<dyn Error>> {
         let (mut mi2, vw2, re_fixed) =
             persistence::new_regressor_from_filename(filename, true, Option::Some(&cl))?;
         mi2.optimizer = model_instance::Optimizer::SGD;
-        match inference_regressor_filename {
-            Some(filename1) => {
-                persistence::save_regressor_to_filename(filename1, &mi2, &vw2, re_fixed).unwrap()
-            }
-            None => {}
+        if let Some(filename1) = inference_regressor_filename {
+            persistence::save_regressor_to_filename(filename1, &mi2, &vw2, re_fixed).unwrap()
         }
     } else {
         let vw: vwmap::VwNamespaceMap;
@@ -329,16 +317,13 @@ fn main2() -> Result<(), Box<dyn Error>> {
         let elapsed = now.elapsed();
         log::info!("Elapsed: {:.2?} rows: {}", elapsed, example_num);
 
-        match final_regressor_filename {
-            Some(filename) => persistence::save_sharable_regressor_to_filename(
-                filename,
-                &mi,
-                &vw,
-                sharable_regressor,
+        if let Some(filename) = final_regressor_filename { persistence::save_sharable_regressor_to_filename(
+            filename,
+            &mi,
+            &vw,
+            sharable_regressor,
             )
-            .unwrap(),
-            None => {}
-        }
+            .unwrap() }
     }
 
     Ok(())

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -217,10 +217,8 @@ impl VowpalParser {
         let mut current_namespace_num_of_features = 0;
 
         unsafe {
-            self.output_buffer
-                .get_unchecked_mut(0..bufpos)
-                .fill(NO_FEATURES);
             self.output_buffer.truncate(bufpos);
+            self.output_buffer.fill(NO_FEATURES);
 
             let p = self.tmp_read_buf.as_ptr();
             let mut i_start: usize;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -113,11 +113,8 @@ fn load_regressor_without_weights(
     let mut mi = model_instance::ModelInstance::new_from_buf(input_bufreader)
         .expect("Loading model instance from regressor failed");
 
-    match cmd_arguments {
-        Some(cmd_args) => {
-            model_instance::ModelInstance::update_hyperparameters_from_cmd(cmd_args, &mut mi)?;
-        }
-        _ => (),
+    if let Some(cmd_args) = cmd_arguments {
+        model_instance::ModelInstance::update_hyperparameters_from_cmd(cmd_args, &mut mi)?;
     }
 
     let mi = mi;


### PR DESCRIPTION
Resolving the following clippy warnings:
- https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow
- https://rust-lang.github.io/rust-clippy/master/index.html#single_match

Smaller additional changes:
- output buffer truncated before filled in parser.rs to prevent unnecessary slice creation
- inlined if into else in block_ffm.rs
- simplified gz var cache.rs