### PR TITLE
0 warning compilation

### DIFF
--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports, unused_mut, invalid_value)]
+
 use core::arch::x86_64::*;
 use rustc_hash::FxHashSet;
 use std::any::Any;
@@ -283,7 +285,7 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockFFM<L> {
                 fb.ffm_buffer.len() * (self.ffm_k * self.ffm_num_fields) as usize;
             if local_data_ffm_len < FFM_STACK_BUF_LEN {
                 // Fast-path - using on-stack data structures
-                let mut local_data_ffm_values: [f32; FFM_STACK_BUF_LEN as usize] =
+                let local_data_ffm_values: [f32; FFM_STACK_BUF_LEN as usize] =
                     MaybeUninit::uninit().assume_init();
                 core_macro!(local_data_ffm_values);
             } else {

--- a/src/block_helpers.rs
+++ b/src/block_helpers.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use crate::optimizer::OptimizerTrait;
 use std::error::Error;
 use std::io;

--- a/src/block_misc.rs
+++ b/src/block_misc.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use std::any::Any;
 use std::error::Error;
 

--- a/src/block_neural.rs
+++ b/src/block_neural.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use rand_distr::{Distribution, Normal, Uniform};
 use rand_xoshiro::rand_core::SeedableRng;
 use rand_xoshiro::Xoshiro256PlusPlus;
@@ -253,11 +255,8 @@ impl<L: OptimizerTrait + 'static> BlockTrait for BlockNeuronLayer<L> {
         unsafe {
             if update && self.neuron_type == NeuronType::WeightedSum {
                 // first we need to initialize inputs to zero
-                // TODO - what to think about this buffer
-                let mut output_errors: [f32; MAX_NUM_INPUTS] = MaybeUninit::uninit().assume_init();
-                output_errors
-                    .get_unchecked_mut(0..self.num_inputs)
-                    .fill(0.0);
+
+                let mut output_errors: [f32; MAX_NUM_INPUTS] = [0.0; MAX_NUM_INPUTS];
 
                 let (input_tape, output_tape) = block_helpers::get_input_output_borrows(
                     &mut pb.tape,

--- a/src/block_relu.rs
+++ b/src/block_relu.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use std::any::Any;
 use std::error::Error;
 

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::error::Error;
 use std::fs;

--- a/src/cmdline.rs
+++ b/src/cmdline.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use crate::version;
 use clap::{App, AppSettings, Arg};
 

--- a/src/feature_buffer.rs
+++ b/src/feature_buffer.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use crate::feature_transform_executor;
 use crate::model_instance;
 use crate::parser;

--- a/src/feature_transform_executor.rs
+++ b/src/feature_transform_executor.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use crate::parser;
 use crate::vwmap;
 use std::error::Error;

--- a/src/feature_transform_implementations.rs
+++ b/src/feature_transform_implementations.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use std::error::Error;
 use std::io::Error as IOError;
 use std::io::ErrorKind;
@@ -216,14 +218,14 @@ impl FunctionExecutorTrait for TransformerLogRatioBinner {
         feature_reader_float_namespace!(
             record_buffer,
             self.from_namespace1.namespace_descriptor,
-            hash_index1,
+            _hash_index1,
             hash_value1,
             float_value1,
             {
                 feature_reader_float_namespace!(
                     record_buffer,
                     self.from_namespace2.namespace_descriptor,
-                    hash_index2,
+                    _hash_index2,
                     hash_value2,
                     float_value2,
                     {

--- a/src/feature_transform_parser.rs
+++ b/src/feature_transform_parser.rs
@@ -1,5 +1,6 @@
 //#[macro_use]
 //extern crate nom;
+#![allow(dead_code,unused_imports)]
 
 use crate::vwmap;
 use serde::{Deserialize, Serialize};
@@ -68,7 +69,7 @@ impl NamespaceTransformsParser {
         }
         let (
             _,
-            (to_namespace_verbose, function_name, from_namespaces_verbose, function_parameters),
+            (to_namespace_verbose, _function_name, from_namespaces_verbose, _function_parameters),
         ) = rr.unwrap();
 
         // Here we just check for clashes with namespaces from input file
@@ -242,7 +243,7 @@ impl NamespaceTransforms {
 }
 
 pub fn get_namespace_descriptor(
-    transform_namespaces: &NamespaceTransforms,
+    _transform_namespaces: &NamespaceTransforms,
     vw: &vwmap::VwNamespaceMap,
     namespace_char: char,
 ) -> Result<vwmap::NamespaceDescriptor, Box<dyn Error>> {

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use crate::block_misc;
 use crate::model_instance;
 use crate::port_buffer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
-#![allow(dead_code)]
-#![allow(unused_imports)]
 #![allow(unused_variables)]
 #![allow(unused_mut)]
 #![allow(non_snake_case)]
 #![allow(redundant_semicolons)]
+#![allow(dead_code,unused_imports)]
 
 use crate::hogwild::HogwildTrainer;
 use crate::multithread_helpers::BoxedRegressorTrait;
@@ -107,7 +106,7 @@ fn build_cache_without_training(cl: clap::ArgMatches) -> Result<(), Box<dyn Erro
             }
         } else {
             reading_result = cache.get_next_record();
-            buffer = match reading_result {
+	    match reading_result {
                 Ok([]) => break, // EOF
                 Ok(buffer) => buffer,
                 Err(_e) => return Err(_e),

--- a/src/model_instance.rs
+++ b/src/model_instance.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use std::error::Error;
 use std::io::Error as IOError;
 use std::io::ErrorKind;

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -124,9 +124,9 @@ impl OptimizerTrait for OptimizerAdagradLUT {
         let minus_power_t = -power_t;
         for x in 0..FASTMATH_LR_LUT_SIZE {
             // accumulated gradients are always positive floating points, sign is guaranteed to be zero
-            // floating point: 1 bit of sign, 7 bits of signed expontent then floating point bits (mantissa)
+            // floating point: 1 bit of sign, 7 bits of signed exponent then floating point bits (mantissa)
             // we will take 7 bits of exponent + whatever most significant bits of mantissa remain
-            // we take two consequtive such values, so we act as if had rounding
+            // we take two consequtive such values, so we act as if it had rounding
             let float_x =
                 (f32::from_bits((x as u32) << (31 - FASTMATH_LR_LUT_BITS))) + initial_acc_gradient;
             let float_x_plus_one =

--- a/src/optimizer.rs
+++ b/src/optimizer.rs
@@ -1,3 +1,4 @@
+#![allow(dead_code,unused_imports)]
 use std::marker::PhantomData;
 
 pub trait OptimizerTrait: std::clone::Clone {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use crate::radix_tree::{NamespaceDescriptorWithHash, RadixTree};
 use crate::vwmap;
 use fasthash::murmur3;

--- a/src/persistence.rs
+++ b/src/persistence.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use std::error::Error;
 use std::str;
 

--- a/src/radix_tree.rs
+++ b/src/radix_tree.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use crate::vwmap::NamespaceDescriptor;
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/src/regressor.rs
+++ b/src/regressor.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use rustc_hash::FxHashSet;
 use std::any::Any;

--- a/src/serving.rs
+++ b/src/serving.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use daemonize::Daemonize;
 use std::error::Error;
 use std::io;

--- a/src/vwmap.rs
+++ b/src/vwmap.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code,unused_imports)]
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::error::Error;


### PR DESCRIPTION
Compiling/inspecting builds prior to this PR results in >100 warnings - many will remain due to source's structure (or quite a few things should be refactored to get rid of them directly). Adding flags to files that are subject to such behavior. At any point, we can always uncomment and deal with warnings explicitly, file-by-file. Further, simplified init in block neural - results are same up to precision (this was one actual warning that could be solved).