### PR TITLE
FFM_STACK_BUF_LEN increase by 30%

### DIFF
--- a/src/block_ffm.rs
+++ b/src/block_ffm.rs
@@ -26,7 +26,7 @@ use crate::regressor;
 use crate::quantization;
 use crate::regressor::{BlockCache, FFM_CONTRA_BUF_LEN};
 
-const FFM_STACK_BUF_LEN: usize = 131072;
+const FFM_STACK_BUF_LEN: usize = 170393;
 const STEP: usize = 4;
 const ZEROES: [f32; STEP] = [0.0; STEP];
 


### PR DESCRIPTION
Heap allocations render training way too slow for competitive updates. This addresses the issues that arise with larger inputs.