### PR TITLE
Ignore elapsed time based test

### DIFF
--- a/src/quantization.rs
+++ b/src/quantization.rs
@@ -160,6 +160,7 @@ mod tests {
     }
 
     #[test]
+    #[ignore]
     fn test_performance() {
         let weights: Vec<f32> = (0..10_000_000).map(|x| x as f32).collect();
         let now = std::time::Instant::now();


### PR DESCRIPTION
Test fails on less capable hardware, so ignoring it